### PR TITLE
Xsd validate schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ There are XML examples  of the use of both protocols. see examples subdirectory.
     See REadme.txt file for list of  changes
  
 
+
+

--- a/README.md
+++ b/README.md
@@ -45,5 +45,3 @@ There are XML examples  of the use of both protocols. see examples subdirectory.
     See REadme.txt file for list of  changes
  
 
-
-

--- a/schema/1.03/xsd/NeTEx_publication-NoConstraint.xsd
+++ b/schema/1.03/xsd/NeTEx_publication-NoConstraint.xsd
@@ -2,7 +2,9 @@
 <!-- edited with XMLSpy v2011 rel. 2 sp1 (x64) (http://www.altova.com) by Christophe Duquesne (Dryade) -->
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_publication">
 	<!-- ===SIRI system IDs for  request =========================================================== -->
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_base-v2.0.xsd"/>
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri_utility/siri_participant-v2.0.xsd"/>
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_requests-v2.0.xsd"/>
 	<!-- ===Regular netex============================================================== -->
 	<xsd:include schemaLocation="netex_service/netex_dataObjectRequest_service-v1.0.xsd"/>
 	<xsd:include schemaLocation="netex_service/netex_all-v1.0.xsd"/>

--- a/schema/1.03/xsd/NeTEx_publication.xsd
+++ b/schema/1.03/xsd/NeTEx_publication.xsd
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_publication">
 	<!-- ===SIRI system IDs for  request =========================================================== -->
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_base-v2.0.xsd"/>
 	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri_utility/siri_participant-v2.0.xsd"/>
+	<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="siri/siri_requests-v2.0.xsd"/>
 	<!-- ===Regular netex============================================================== -->
 	<xsd:include schemaLocation="netex_service/netex_dataObjectRequest_service-v1.0.xsd"/>
 	<xsd:include schemaLocation="netex_service/netex_all-v1.0.xsd"/>

--- a/schema/1.03/xsd/netex_framework/netex_frames/netex_compositeFrame_version-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_frames/netex_compositeFrame_version-v1.0.xsd
@@ -1,1 +1,151 @@
-<?xml version="1.0" encoding="iso-8859-1"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_compositeFrame_version">	<xsd:include schemaLocation="../../netex_framework/netex_frames/netex_commonFrame_version-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2011-12-16</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines COMPOSITE FRAME types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_frames}netex_compositeFrame_version-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the SIRI standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network exchange - COMPOSITE FRAMEtypes.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>COMPOSITE FRAME types of NeTEx.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:simpleType name="CompositeFrameIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a COMPOSITE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="VersionFrameIdType"/>	</xsd:simpleType>	<xsd:element name="CompositeFrameRef" type="CompositeFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">		<xsd:annotation>			<xsd:documentation>Reference to a COMPOSITE FRAME.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="CompositeFrameRefStructure" abstract="false">		<xsd:annotation>			<xsd:documentation>Type for a reference to a COMPOSITE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionFrameRefStructure">				<xsd:attribute name="ref" type="CompositeFrameIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a COMPOSITE FRAME.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:complexType name="frames_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a collection of FRAMEs.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="containmentAggregationStructure">				<xsd:sequence>					<xsd:element ref="CommonFrame" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:element name="CompositeFrame" abstract="false" substitutionGroup="VersionFrame">		<xsd:annotation>			<xsd:documentation>A container VERSION FRAME that groups a set of content VERSION FRAMsE to which the same VALIDITY CONDITIONs have been assigned.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="Composite_VersionFrameStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="VersionFrameGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="CompositeVersionFrameGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="CompositeFrameIdType">						<xsd:annotation>							<xsd:documentation>identifier of Frame.</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="Composite_VersionFrameStructure" abstract="false">		<xsd:annotation>			<xsd:documentation>Type for a COMPOSITE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="Common_VersionFrameStructure">				<xsd:sequence>					<xsd:group ref="CompositeVersionFrameGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="CompositeVersionFrameGroup">		<xsd:annotation>			<xsd:documentation>Elements of a COMPOSITE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="frames" type="frames_RelStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Content frames in COMPOSITE FRAME.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_compositeFrame_version">
+	<xsd:include schemaLocation="../../netex_framework/netex_frames/netex_commonFrame_version-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2011-12-16</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines COMPOSITE FRAME types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_frames}netex_compositeFrame_version-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the SIRI standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network exchange - COMPOSITE FRAMEtypes.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>COMPOSITE FRAME types of NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="CompositeFrameIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a COMPOSITE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="VersionFrameIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="CompositeFrameRef" type="CompositeFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a COMPOSITE FRAME.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="CompositeFrameRefStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a COMPOSITE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionFrameRefStructure">
+				<xsd:attribute name="ref" type="CompositeFrameIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a COMPOSITE FRAME.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="frames_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a collection of FRAMEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="CommonFrame" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="CompositeFrame" abstract="false" substitutionGroup="VersionFrame">
+		<xsd:annotation>
+			<xsd:documentation>A container VERSION FRAME that groups a set of content VERSION FRAMsE to which the same VALIDITY CONDITIONs have been assigned.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="Composite_VersionFrameStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionFrameGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="CompositeVersionFrameGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="CompositeFrameIdType">
+						<xsd:annotation>
+							<xsd:documentation>identifier of Frame.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="Composite_VersionFrameStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a COMPOSITE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="Common_VersionFrameStructure">
+				<xsd:sequence>
+					<xsd:group ref="CompositeVersionFrameGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="CompositeVersionFrameGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements of a COMPOSITE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="frames" type="frames_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Content frames in COMPOSITE FRAME.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_frames/netex_resourceFrame_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_frames/netex_resourceFrame_support-v1.0.xsd
@@ -1,1 +1,84 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_resourceFrame_support">	<xsd:include schemaLocation="../netex_responsibility/netex_versionFrame_support-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2010-11-05</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines RESOURCE FRAME types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_frames}netex_resourceFrame_support-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - RESOURCE FRAME types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>RESOURCE FRAME types for NeTEx.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:simpleType name="ResourceFrameIdType">		<xsd:annotation>			<xsd:documentation>Identifier of a RESOURCE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="VersionFrameIdType"/>	</xsd:simpleType>	<xsd:element name="ResourceFrameRef" type="ResourceFrameRefStructure" abstract="false" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation> Reference to a RESOURCE FRAME.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ResourceFrameRefStructure" abstract="false">		<xsd:annotation>			<xsd:documentation>Type for a reference to a RESOURCE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="ResourceFrameIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_resourceFrame_support">
+	<xsd:include schemaLocation="../netex_responsibility/netex_versionFrame_support-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2010-11-05</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines RESOURCE FRAME types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_frames}netex_resourceFrame_support-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - RESOURCE FRAME types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>RESOURCE FRAME types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="ResourceFrameIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a RESOURCE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="VersionFrameIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="ResourceFrameRef" type="ResourceFrameRefStructure" abstract="false" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation> Reference to a RESOURCE FRAME.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ResourceFrameRefStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a RESOURCE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="ResourceFrameIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_frames/netex_serviceCalendarFrame_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_frames/netex_serviceCalendarFrame_support-v1.0.xsd
@@ -1,1 +1,89 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) --><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_serviceCalendar_support">	<xsd:include schemaLocation="../netex_responsibility/netex_versionFrame_support-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2010-11-05</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines SERVICE CALENDAR  FRAME identifier types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_frames}netex_serviceCalendarFrame_support-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - SERVICE CALENDAR  FRAME types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SERVICE CALENDAR FRAME identifier  types for NeTEx.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:simpleType name="ServiceCalendarFrameIdType">		<xsd:annotation>			<xsd:documentation>Identifier of a SERVICE CALENDAR FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="VersionFrameIdType"/>	</xsd:simpleType>	<xsd:element name="ServiceCalendarFrameRef" substitutionGroup="VersionFrameRef">		<xsd:annotation>			<xsd:documentation> Reference to a SERVICE CALENDAR FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:extension base="ServiceCalendarFrameRefStructure"/>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="ServiceCalendarFrameRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SERVICE CALENDAR FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionFrameRefStructure">				<xsd:attribute name="ref" type="ServiceCalendarFrameIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of SERVICE CALENDAR FRAME.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_serviceCalendar_support">
+	<xsd:include schemaLocation="../netex_responsibility/netex_versionFrame_support-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2010-11-05</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines SERVICE CALENDAR  FRAME identifier types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_frames}netex_serviceCalendarFrame_support-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - SERVICE CALENDAR  FRAME types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SERVICE CALENDAR FRAME identifier  types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="ServiceCalendarFrameIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SERVICE CALENDAR FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="VersionFrameIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="ServiceCalendarFrameRef" substitutionGroup="VersionFrameRef">
+		<xsd:annotation>
+			<xsd:documentation> Reference to a SERVICE CALENDAR FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="ServiceCalendarFrameRefStructure"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="ServiceCalendarFrameRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SERVICE CALENDAR FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionFrameRefStructure">
+				<xsd:attribute name="ref" type="ServiceCalendarFrameIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of SERVICE CALENDAR FRAME.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_genericFramework/netex_accessibility/netex_acsb_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_genericFramework/netex_accessibility/netex_acsb_support-v1.0.xsd
@@ -1,1 +1,120 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2010 rel. 3 sp1 (http://www.altova.com) by Nicholas Knowles (Kizoom) --><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_acsb_support">	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2010-11-05</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines common accessibility types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_genericFramework/netex_accessibility}netex_acsb_support-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - ACCESSIBILITY identifier types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>NeTEx ACCESSIBILITY identifier types for IFOPT Fixed Objects in Public Transport.</xsd:documentation>	</xsd:annotation>	<xsd:include schemaLocation="../../netex_responsibility/netex_relationship-v1.0.xsd"/>	<!--===========================================================================================-->	<xsd:simpleType name="LimitationIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of an ACCESSIBILITY LIMITATION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:complexType name="LimitationRefStructure">		<xsd:annotation>			<xsd:documentation>Type for reference to an ACCESSIBILITY LIMITATION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="LimitationIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!--===========================================================================================-->	<xsd:simpleType name="AccessibilityAssessmentIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of an ACCESSIBILITY ASSESSMENT.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:element name="AccessibilityAssessmentRef" type="AccessibilityAssessmentRefStructure">		<xsd:annotation>			<xsd:documentation>Reference to an ACCESSIBILITY ASSESSMENT.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AccessibilityAssessmentRefStructure">		<xsd:annotation>			<xsd:documentation>Type for reference to an ACCESSIBILITY ASSESSMENT.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="AccessibilityAssessmentIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!--===========================================================================================-->	<xsd:simpleType name="SuitabilityIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a SUITABILITY.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<!--===========================================================================================-->	<xsd:simpleType name="UserNeedIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a User Need.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<!--======Point=======================================================================================--></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2010 rel. 3 sp1 (http://www.altova.com) by Nicholas Knowles (Kizoom) -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_acsb_support">
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2010-11-05</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines common accessibility types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_genericFramework/netex_accessibility}netex_acsb_support-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - ACCESSIBILITY identifier types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEx ACCESSIBILITY identifier types for IFOPT Fixed Objects in Public Transport.</xsd:documentation>
+	</xsd:annotation>
+	<xsd:include schemaLocation="../../netex_responsibility/netex_relationship-v1.0.xsd"/>
+	<!--===========================================================================================-->
+	<xsd:simpleType name="LimitationIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of an ACCESSIBILITY LIMITATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:complexType name="LimitationRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for reference to an ACCESSIBILITY LIMITATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="LimitationIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--===========================================================================================-->
+	<xsd:simpleType name="AccessibilityAssessmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of an ACCESSIBILITY ASSESSMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="AccessibilityAssessmentRef" type="AccessibilityAssessmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an ACCESSIBILITY ASSESSMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AccessibilityAssessmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for reference to an ACCESSIBILITY ASSESSMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="AccessibilityAssessmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--===========================================================================================-->
+	<xsd:simpleType name="SuitabilityIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a SUITABILITY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<!--===========================================================================================-->
+	<xsd:simpleType name="UserNeedIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a User Need.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<!--======Point=======================================================================================-->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_genericFramework/netex_projection_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_genericFramework/netex_projection_support-v1.0.xsd
@@ -1,1 +1,248 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="01." id="netex_projection_support">	<xsd:include schemaLocation="netex_spatialFeature_support-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2010-11-05</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines PROJECTION types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>		 		<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_genericFramework}netex_projection_support-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - PROJECTION identifier types. </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>PROJECTION identifier types for NeTEx.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<!-- ======================================================================= -->	<xsd:simpleType name="ProjectionIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:element name="ProjectionRef" type="ProjectionRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation>Reference to a PROJECTION.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ProjectionRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="ProjectionIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a PROJECTION.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="PointProjectionIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a POINT PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ProjectionIdType"/>	</xsd:simpleType>	<xsd:element name="PointProjectionRef" type="PointProjectionRefStructure" substitutionGroup="ProjectionRef">		<xsd:annotation>			<xsd:documentation>Reference to a PROJECTION.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="PointProjectionRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a POINT PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="ProjectionRefStructure">				<xsd:attribute name="ref" type="PointProjectionIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a POINT PROJECTION.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="LinkProjectionIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a LINK PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ProjectionIdType"/>	</xsd:simpleType>	<xsd:element name="LinkProjectionRef" type="LinkProjectionRefStructure" substitutionGroup="ProjectionRef">		<xsd:annotation>			<xsd:documentation>Reference to a PROJECTION.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="LinkProjectionRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a LINK PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="ProjectionRefStructure">				<xsd:attribute name="ref" type="LinkProjectionIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a LINK PROJECTION.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="ZoneProjectionIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a ZONE PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ProjectionIdType"/>	</xsd:simpleType>	<xsd:element name="ZoneProjectionRef" type="ZoneProjectionRefStructure" substitutionGroup="ProjectionRef">		<xsd:annotation>			<xsd:documentation>Reference to a PROJECTION.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ZoneProjectionRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a ZONE PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="ProjectionRefStructure">				<xsd:attribute name="ref" type="ZoneProjectionIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a ZONE PROJECTION.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="LinkSequenceProjectionRef" type="LinkSequenceProjectionRefStructure" substitutionGroup="ProjectionRef">		<xsd:annotation>			<xsd:documentation>Reference to a LINK SEQUENCE PROJECTION.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:simpleType name="LinkSequenceProjectionIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a LINK SEQUENCE PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ProjectionIdType"/>	</xsd:simpleType>	<xsd:complexType name="LinkSequenceProjectionRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a LINK SEQUENCE PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="ProjectionRefStructure">				<xsd:attribute name="ref" type="LinkSequenceProjectionIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a PROJECTION.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="ComplexFeatureProjectionRef" type="ComplexFeatureProjectionRefStructure" substitutionGroup="ProjectionRef">		<xsd:annotation>			<xsd:documentation>Reference to a COMPLEX FEATURE PROJECTION.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:simpleType name="ComplexFeatureProjectionIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a COMPLEX FEATURE PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ProjectionIdType"/>	</xsd:simpleType>	<xsd:complexType name="ComplexFeatureProjectionRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a COMPLEX FEATURE PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="ProjectionRefStructure">				<xsd:attribute name="ref" type="ComplexFeatureProjectionIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a PROJECTION.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="LineShapeIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a LINE SHAPE.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ProjectionIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:simpleType name="TypeOfProjectionIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a TYPE OF PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="TypeOfValueIdType"/>	</xsd:simpleType>	<xsd:element name="TypeOfProjectionRef" type="TypeOfProjectionRefStructure" substitutionGroup="TypeOfEntityRef">		<xsd:annotation>			<xsd:documentation>Reference to a TYPE OF PROJECTION.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="TypeOfProjectionRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a TYPE OF PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="TypeOfValueRefStructure">				<xsd:attribute name="ref" type="TypeOfProjectionIdType" use="required">					<xsd:annotation>						<xsd:documentation>Reference to a TYPE OF PROJECTION.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="01." id="netex_projection_support">
+	<xsd:include schemaLocation="netex_spatialFeature_support-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2010-11-05</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines PROJECTION types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+		 		<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_genericFramework}netex_projection_support-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - PROJECTION identifier types. </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>PROJECTION identifier types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="ProjectionIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="ProjectionRef" type="ProjectionRefStructure" abstract="true" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ProjectionRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="ProjectionIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PROJECTION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="PointProjectionIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a POINT PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ProjectionIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PointProjectionRef" type="PointProjectionRefStructure" substitutionGroup="ProjectionRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PointProjectionRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a POINT PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="ProjectionRefStructure">
+				<xsd:attribute name="ref" type="PointProjectionIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a POINT PROJECTION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="LinkProjectionIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a LINK PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ProjectionIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="LinkProjectionRef" type="LinkProjectionRefStructure" substitutionGroup="ProjectionRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="LinkProjectionRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a LINK PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="ProjectionRefStructure">
+				<xsd:attribute name="ref" type="LinkProjectionIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a LINK PROJECTION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="ZoneProjectionIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a ZONE PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ProjectionIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="ZoneProjectionRef" type="ZoneProjectionRefStructure" substitutionGroup="ProjectionRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ZoneProjectionRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a ZONE PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="ProjectionRefStructure">
+				<xsd:attribute name="ref" type="ZoneProjectionIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a ZONE PROJECTION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="LinkSequenceProjectionRef" type="LinkSequenceProjectionRefStructure" substitutionGroup="ProjectionRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a LINK SEQUENCE PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:simpleType name="LinkSequenceProjectionIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a LINK SEQUENCE PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ProjectionIdType"/>
+	</xsd:simpleType>
+	<xsd:complexType name="LinkSequenceProjectionRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a LINK SEQUENCE PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="ProjectionRefStructure">
+				<xsd:attribute name="ref" type="LinkSequenceProjectionIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PROJECTION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="ComplexFeatureProjectionRef" type="ComplexFeatureProjectionRefStructure" substitutionGroup="ProjectionRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a COMPLEX FEATURE PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:simpleType name="ComplexFeatureProjectionIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a COMPLEX FEATURE PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ProjectionIdType"/>
+	</xsd:simpleType>
+	<xsd:complexType name="ComplexFeatureProjectionRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a COMPLEX FEATURE PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="ProjectionRefStructure">
+				<xsd:attribute name="ref" type="ComplexFeatureProjectionIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PROJECTION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="LineShapeIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a LINE SHAPE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ProjectionIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="TypeOfProjectionIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a TYPE OF PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TypeOfValueIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="TypeOfProjectionRef" type="TypeOfProjectionRefStructure" substitutionGroup="TypeOfEntityRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a TYPE OF PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="TypeOfProjectionRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TYPE OF PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="TypeOfValueRefStructure">
+				<xsd:attribute name="ref" type="TypeOfProjectionIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Reference to a TYPE OF PROJECTION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_genericFramework/netex_zoneProjection_version-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_genericFramework/netex_zoneProjection_version-v1.0.xsd
@@ -1,1 +1,139 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="01." id="netex_zoneProjection_version">	<xsd:include schemaLocation="netex_zone_version-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2010-11-05</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines ZONE PROJECTION types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_genericFramework}netex_zoneProjection_version-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - Base types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>ZONE PROJECTION types for NeTEx.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:element name="ZoneProjection" abstract="false" substitutionGroup="Projection">		<xsd:annotation>			<xsd:documentation>An oriented correspondence from one ZONE in a source layer,  onto a target entity : e.g.  POINT, COMPLEX FEATURE, within a defined TYPE OF PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="ZoneProjection_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="ProjectionGroup">								<xsd:annotation>									<xsd:documentation>Common Properties of a PROJECTION.</xsd:documentation>								</xsd:annotation>							</xsd:group>						</xsd:sequence>						<xsd:sequence>							<xsd:element name="ProjectedZoneRef" type="ZoneRefStructure">								<xsd:annotation>									<xsd:documentation>Reference to ZONE to which ZONE projects.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="ProjectToZoneRef" type="ZoneRefStructure" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Reference to ZONE onto to which ZONE projects.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="ProjectToPointRef" type="PointRefStructure" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Reference to POINT to which centre of ZONE projects.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="points" type="pointRefs_RelStructure" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Sequence of points making up PROJECTION.</xsd:documentation>								</xsd:annotation>							</xsd:element>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="ZoneProjectionIdType"/>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="ZoneProjection_VersionStructure" abstract="false">		<xsd:annotation>			<xsd:documentation>Type for a ZONE PROJECTION.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="Projection_VersionStructure">				<xsd:sequence>					<xsd:element name="ProjectedZoneRef" type="ZoneRefStructure">						<xsd:annotation>							<xsd:documentation>ZONE being projected.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="ProjectToZoneRef" type="ZoneRefStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Reference to ZONE onto to which ZONE projects.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="ProjectToPointRef" type="PointRefStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Reference to POINT to which centre of ZONE projects.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="points" type="pointRefs_RelStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Sequence of points making up PROJECTION.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="01." id="netex_zoneProjection_version">
+	<xsd:include schemaLocation="netex_zone_version-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2010-11-05</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines ZONE PROJECTION types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_genericFramework}netex_zoneProjection_version-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel, VDV, TransXChange, NaPTAN, NOPTIS, BISON and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - Base types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>ZONE PROJECTION types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:element name="ZoneProjection" abstract="false" substitutionGroup="Projection">
+		<xsd:annotation>
+			<xsd:documentation>An oriented correspondence from one ZONE in a source layer,  onto a target entity : e.g.  POINT, COMPLEX FEATURE, within a defined TYPE OF PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="ZoneProjection_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="ProjectionGroup">
+								<xsd:annotation>
+									<xsd:documentation>Common Properties of a PROJECTION.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:group>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:element name="ProjectedZoneRef" type="ZoneRefStructure">
+								<xsd:annotation>
+									<xsd:documentation>Reference to ZONE to which ZONE projects.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="ProjectToZoneRef" type="ZoneRefStructure" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Reference to ZONE onto to which ZONE projects.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="ProjectToPointRef" type="PointRefStructure" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Reference to POINT to which centre of ZONE projects.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="points" type="pointRefs_RelStructure" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Sequence of points making up PROJECTION.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="ZoneProjectionIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="ZoneProjection_VersionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a ZONE PROJECTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="Projection_VersionStructure">
+				<xsd:sequence>
+					<xsd:element name="ProjectedZoneRef" type="ZoneRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>ZONE being projected.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ProjectToZoneRef" type="ZoneRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Reference to ZONE onto to which ZONE projects.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ProjectToPointRef" type="PointRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Reference to POINT to which centre of ZONE projects.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="points" type="pointRefs_RelStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Sequence of points making up PROJECTION.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_responsibility/netex_dataSource_version-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_responsibility/netex_dataSource_version-v1.0.xsd
@@ -1,1 +1,173 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_dataSource_version">	<xsd:include schemaLocation="netex_typeOfValue_version-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2010-11-05</Modified>				</Date>				<Description>					<p>NeTEx Network Exchange - This subschema defines DATA SOURCE types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_responsibility}netex_dataSource_version-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Created for NeTEx.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - DATA SOURCE  types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>NeTEX: DATA SOURCE type.</xsd:documentation>	</xsd:annotation>	<!-- ===DATA SOURCE  IN FRAME====Used in RESOURCE FRAME)=================================================== -->	<xsd:complexType name="dataSourcesInFrame_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for containment in frame of DATA SOURCE.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="containmentAggregationStructure">				<xsd:sequence>					<xsd:element ref="DataSource" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:complexType name="dataSources_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for list of DATA SOURCEs.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="containmentAggregationStructure">				<xsd:choice maxOccurs="unbounded">					<xsd:element ref="DataSourceRef"/>					<xsd:element ref="DataSource"/>				</xsd:choice>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<!-- ======================================================================= -->	<xsd:element name="DataSource" substitutionGroup="TypeOfValue">		<xsd:annotation>			<xsd:documentation>Identifies the system which has produced the data.References to a DATA SOURCE are useful in an interoperated computer system.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="DataSource_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="TypeOfValueGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:element name="Email" type="EmailAddressType" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Contact email for data queries.</xsd:documentation>								</xsd:annotation>							</xsd:element>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="DataSourceIdType">						<xsd:annotation>							<xsd:documentation>Identifier of DATA SOURCE.</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="DataSource_VersionStructure">		<xsd:annotation>			<xsd:documentation>Type for DATA SOURCE.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="TypeOfValue_VersionStructure">				<xsd:group ref="DataSourceGroup"/>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="DataSourceGroup">		<xsd:annotation>			<xsd:documentation>for  DATA SOURCE.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Email" type="EmailAddressType" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Contact email for data queries.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= -->	<xsd:element name="Branding" substitutionGroup="TypeOfValue">		<xsd:annotation>			<xsd:documentation>An arbitrary marketing classification.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="Branding_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="TypeOfValueGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="derivedFromObjectRef" type="BrandingIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identity of object from which this object of ENTITY was derived. Normally the same.</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="Branding_VersionStructure">		<xsd:annotation>			<xsd:documentation>Type for a BRANDING.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="TypeOfValue_VersionStructure"/>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_dataSource_version">
+	<xsd:include schemaLocation="netex_typeOfValue_version-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2010-11-05</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx Network Exchange - This subschema defines DATA SOURCE types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_responsibility}netex_dataSource_version-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Created for NeTEx.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - DATA SOURCE  types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEX: DATA SOURCE type.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ===DATA SOURCE  IN FRAME====Used in RESOURCE FRAME)=================================================== -->
+	<xsd:complexType name="dataSourcesInFrame_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for containment in frame of DATA SOURCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="DataSource" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="dataSources_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for list of DATA SOURCEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="DataSourceRef"/>
+					<xsd:element ref="DataSource"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<!-- ======================================================================= -->
+	<xsd:element name="DataSource" substitutionGroup="TypeOfValue">
+		<xsd:annotation>
+			<xsd:documentation>Identifies the system which has produced the data.
+References to a DATA SOURCE are useful in an interoperated computer system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="DataSource_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="TypeOfValueGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:element name="Email" type="EmailAddressType" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Contact email for data queries.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="DataSourceIdType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of DATA SOURCE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="DataSource_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for DATA SOURCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="TypeOfValue_VersionStructure">
+				<xsd:group ref="DataSourceGroup"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DataSourceGroup">
+		<xsd:annotation>
+			<xsd:documentation>for  DATA SOURCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Email" type="EmailAddressType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Contact email for data queries.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="Branding" substitutionGroup="TypeOfValue">
+		<xsd:annotation>
+			<xsd:documentation>An arbitrary marketing classification.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="Branding_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="TypeOfValueGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="derivedFromObjectRef" type="BrandingIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identity of object from which this object of ENTITY was derived. Normally the same.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="Branding_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a BRANDING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="TypeOfValue_VersionStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_responsibility/netex_version_version-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_responsibility/netex_version_version-v1.0.xsd
@@ -1,1 +1,221 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_version_version">	<xsd:include schemaLocation="../netex_utility/netex_utility_contact-v1.0.xsd"/>	<xsd:include schemaLocation="netex_entity_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_responsibility_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_version_support-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2014-03-31</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines VERSION types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_responsibility}netex_version_version-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Created for NeTEx.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - ENTITY types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>NeTEx: VERSION types for NeTEx.</xsd:documentation>	</xsd:annotation>	<!-- ===ENTIITY IN VERSION IN FRAME====Used in RESOURCE FRAME)=================================================== -->	<!--CLOSE COUPLED WITH  netex_responsibility_version-->	<xsd:complexType name="versionsInFrame_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for containment in frame of VERSION.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="containmentAggregationStructure">				<xsd:sequence>					<xsd:element ref="Version" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:complexType name="entitiesInVersion_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for containment in ENTITY of ENTITY In VERSION.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="containmentAggregationStructure">				<xsd:sequence>					<xsd:element ref="EntityInVersion" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:element name="EntityInVersion" type="EntityInVersionStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>The ENTITies associated to a given VERSION. ENTITY IN VERSION is restricted by ENTITY IN FRAME.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="EntityInVersionStructure">		<xsd:annotation>			<xsd:documentation>Type for ENTITY IN VERSION.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="EntityStructure">				<xsd:sequence>					<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>				</xsd:sequence>				<xsd:attribute name="dataSourceRef" type="DataSourceIdType" use="optional">					<xsd:annotation>						<xsd:documentation>Name of source of the data.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>				<xsd:attributeGroup ref="BasicModificationDetailsGroup"/>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="EntityInVersionGroup">		<xsd:annotation>			<xsd:documentation>Common Properties of an ENTITY IN VERSION.</xsd:documentation>		</xsd:annotation>		<xsd:choice>			<xsd:element name="validityConditions" type="validityConditions_RelStructure">				<xsd:annotation>					<xsd:documentation>VALIDITY CONDITIONs conditioning entity.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element ref="ValidBetween" maxOccurs="unbounded"/>		</xsd:choice>	</xsd:group>	<!-- ======================================================================= -->	<xsd:complexType name="versions_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for containment of a VERSION.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="containmentAggregationStructure">				<xsd:choice maxOccurs="unbounded">					<xsd:element ref="VersionRef"/>					<xsd:element ref="Version"/>				</xsd:choice>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:element name="Version" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A group of operational data instances which share the same VALIDITY CONDITIONs. A VERSION belongs to a unique VERSION FRAME and is characterized by a unique TYPE OF VERSION. E.g.  NETWORK VERSION for Line 12 starting from 2000-01-01.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="Version_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:element name="StartDate" type="xsd:dateTime" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Date of start of VERSION currency.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="EndDate" type="xsd:dateTime" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Date of end of VERSION currency. Date is INCLUSIVE.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="Status" type="VersionStatusEnumeration" default="versioned" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Status of VERSION.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>							<xsd:element name="VersionType" type="VersionTypeEnumeration" default="point" minOccurs="0">								<xsd:annotation>									<xsd:documentation>VERSION type: Point or Baseline.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="DerivedFromVersionRef" type="VersionRefStructure" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Reference to VERSION from which this VERSION was derived.</xsd:documentation>								</xsd:annotation>							</xsd:element>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="VersionIdType"/>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="Version_VersionStructure">		<xsd:annotation>			<xsd:documentation>Type for a VERSION.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="DataManagedObjectStructure">				<xsd:sequence>					<xsd:element name="StartDate" type="xsd:dateTime" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Date of start of VERSION currency.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="EndDate" type="xsd:dateTime" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Date of end of VERSION currency. Date is INCLUSIVE.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="Status" type="VersionStatusEnumeration" default="versioned" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Status of VERSION.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>					<xsd:element name="VersionType" type="VersionTypeEnumeration" default="point" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Version type: Point or Baseline.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="DerivedFromVersionRef" type="VersionRefStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Reference to VERSION from which this VERSION was derived.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_version_version">
+	<xsd:include schemaLocation="../netex_utility/netex_utility_contact-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_entity_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_responsibility_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_version_support-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2014-03-31</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines VERSION types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_responsibility}netex_version_version-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Created for NeTEx.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - ENTITY types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEx: VERSION types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ===ENTIITY IN VERSION IN FRAME====Used in RESOURCE FRAME)=================================================== -->
+	<!--CLOSE COUPLED WITH  netex_responsibility_version-->
+	<xsd:complexType name="versionsInFrame_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for containment in frame of VERSION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="Version" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="entitiesInVersion_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for containment in ENTITY of ENTITY In VERSION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="EntityInVersion" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="EntityInVersion" type="EntityInVersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>The ENTITies associated to a given VERSION. ENTITY IN VERSION is restricted by ENTITY IN FRAME.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="EntityInVersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for ENTITY IN VERSION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="EntityStructure">
+				<xsd:sequence>
+					<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="dataSourceRef" type="DataSourceIdType" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>Name of source of the data.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attributeGroup ref="BasicModificationDetailsGroup"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="EntityInVersionGroup">
+		<xsd:annotation>
+			<xsd:documentation>Common Properties of an ENTITY IN VERSION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element name="validityConditions" type="validityConditions_RelStructure">
+				<xsd:annotation>
+					<xsd:documentation>VALIDITY CONDITIONs conditioning entity.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ValidBetween" maxOccurs="unbounded"/>
+		</xsd:choice>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="versions_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for containment of a VERSION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="VersionRef"/>
+					<xsd:element ref="Version"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="Version" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A group of operational data instances which share the same VALIDITY CONDITIONs. A VERSION belongs to a unique VERSION FRAME and is characterized by a unique TYPE OF VERSION. E.g.  NETWORK VERSION for Line 12 starting from 2000-01-01.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="Version_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:element name="StartDate" type="xsd:dateTime" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Date of start of VERSION currency.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="EndDate" type="xsd:dateTime" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Date of end of VERSION currency. Date is INCLUSIVE.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="Status" type="VersionStatusEnumeration" default="versioned" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Status of VERSION.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
+							<xsd:element name="VersionType" type="VersionTypeEnumeration" default="point" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>VERSION type: Point or Baseline.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="DerivedFromVersionRef" type="VersionRefStructure" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Reference to VERSION from which this VERSION was derived.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="VersionIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="Version_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a VERSION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:sequence>
+					<xsd:element name="StartDate" type="xsd:dateTime" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Date of start of VERSION currency.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="EndDate" type="xsd:dateTime" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Date of end of VERSION currency. Date is INCLUSIVE.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Status" type="VersionStatusEnumeration" default="versioned" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Status of VERSION.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
+					<xsd:element name="VersionType" type="VersionTypeEnumeration" default="point" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Version type: Point or Baseline.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="DerivedFromVersionRef" type="VersionRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Reference to VERSION from which this VERSION was derived.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_address_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_address_support-v1.0.xsd
@@ -1,1 +1,166 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) --><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_address_support">	<xsd:include schemaLocation="../netex_genericFramework/netex_place_support-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor>V1.0 Christophe Duquesne</Contributor>				<Contributor>Nicholas Knowles</Contributor>				<Coverage>Europe</Coverage>				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Description>					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>					<p>This sub-schema describes the ACCESS Types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}anetex_address_support.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>				<Relation>					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile-v1.0.xsd</Requires>				</Relation>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the Transmodel, VDV, TransXChange, NEPTUNE, BISON and Trident standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx ACCESS Types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>NeTEx ADDRESS Identifier types.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<!--=============================================================================-->	<xsd:simpleType name="AddressIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of an ADDRESS.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="PlaceIdType"/>	</xsd:simpleType>	<xsd:element name="AddressRef" type="AddressRefStructure" substitutionGroup="PlaceRef_">		<xsd:annotation>			<xsd:documentation>Reference to an ADDRESS.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AddressRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to an ADDRESS.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="PlaceRefStructure">				<xsd:attribute name="ref" type="AddressIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of an ADDRESS.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!--=============================================================================-->	<xsd:simpleType name="AddressablePlaceIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of an ADDRESSED PLACE.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="PlaceIdType"/>	</xsd:simpleType>	<xsd:element name="AddressablePlaceRef" type="AddressablePlaceRefStructure" substitutionGroup="PlaceRef_">		<xsd:annotation>			<xsd:documentation>Reference to an ADDRESSED PLACE.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AddressablePlaceRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to an ADDRESSED PLACE.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="PlaceRefStructure">				<xsd:attribute name="ref" type="AddressablePlaceIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of an AddressedPlace.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!--=============================================================================-->	<xsd:simpleType name="RoadAddressIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a Road ADDRESS.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="AddressIdType"/>	</xsd:simpleType>	<xsd:element name="RoadAddressRef" type="RoadAddressRefStructure" substitutionGroup="AddressRef">		<xsd:annotation>			<xsd:documentation>Reference to a Road ADDRESS.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="RoadAddressRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a TYPE OF ACTIVATION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="AddressRefStructure">				<xsd:attribute name="ref" type="RoadAddressIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a ROAD ADDRESS.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="PostalAddressIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a POSTAL ADDRESS.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="AddressIdType"/>	</xsd:simpleType>	<xsd:element name="PostalAddressRef" type="PostalAddressRefStructure" substitutionGroup="AddressRef">		<xsd:annotation>			<xsd:documentation>Reference to a POSTAL ADDRESS.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="PostalAddressRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a TYPE OF ACTIVATION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="AddressRefStructure">				<xsd:attribute name="ref" type="PostalAddressIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a POSTAL ADDRESS.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!--=============================================================================--></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_address_support">
+	<xsd:include schemaLocation="../netex_genericFramework/netex_place_support-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Christophe Duquesne</Contributor>
+				<Contributor>Nicholas Knowles</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for NeTEx version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx is a European CEN standard for the exchange of Public Transport data including timetables.</p>
+					<p>This sub-schema describes the ACCESS Types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}anetex_address_support.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/PATH/netex_prereqfile-v1.0.xsd</Requires>
+				</Relation>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the Transmodel, VDV, TransXChange, NEPTUNE, BISON and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx ACCESS Types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEx ADDRESS Identifier types.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<!--=============================================================================-->
+	<xsd:simpleType name="AddressIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of an ADDRESS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="PlaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="AddressRef" type="AddressRefStructure" substitutionGroup="PlaceRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an ADDRESS.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AddressRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an ADDRESS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="PlaceRefStructure">
+				<xsd:attribute name="ref" type="AddressIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of an ADDRESS.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--=============================================================================-->
+	<xsd:simpleType name="AddressablePlaceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of an ADDRESSED PLACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="PlaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="AddressablePlaceRef" type="AddressablePlaceRefStructure" substitutionGroup="PlaceRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an ADDRESSED PLACE.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AddressablePlaceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an ADDRESSED PLACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="PlaceRefStructure">
+				<xsd:attribute name="ref" type="AddressablePlaceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of an AddressedPlace.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--=============================================================================-->
+	<xsd:simpleType name="RoadAddressIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a Road ADDRESS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AddressIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="RoadAddressRef" type="RoadAddressRefStructure" substitutionGroup="AddressRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a Road ADDRESS.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="RoadAddressRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TYPE OF ACTIVATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AddressRefStructure">
+				<xsd:attribute name="ref" type="RoadAddressIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a ROAD ADDRESS.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="PostalAddressIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a POSTAL ADDRESS.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AddressIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PostalAddressRef" type="PostalAddressRefStructure" substitutionGroup="AddressRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a POSTAL ADDRESS.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PostalAddressRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TYPE OF ACTIVATION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AddressRefStructure">
+				<xsd:attribute name="ref" type="PostalAddressIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a POSTAL ADDRESS.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--=============================================================================-->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_alternativeName_version-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_alternativeName_version-v1.0.xsd
@@ -1,1 +1,204 @@
-<?xml version="1.0" encoding="UTF-8"?> <xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_alternativeName_version">	<xsd:include schemaLocation="../../netex_framework/netex_responsibility/netex_responsibility_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_alternativeName_support-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2007-03-12</Created>				</Date>				<Date>					<Modified>2011-12-16</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines STOP PLACE path types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_alternativeName_version-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the SIRI standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange -  ALTERNATIVE NAME  Base types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>Basic name types for IFOPT Fixed Objects in Public Transport.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<!-- Simple Type Definitions -->	<xsd:complexType name="alternativeNames_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for list of ALTERNATIVE NAMEs.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="strictContainmentAggregationStructure">				<xsd:sequence>					<xsd:element ref="AlternativeName" maxOccurs="unbounded">						<xsd:annotation>							<xsd:documentation>ALTERNATIVE NAME for Element.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:element name="AlternativeName" substitutionGroup="VersionedChild">		<xsd:annotation>			<xsd:documentation>Alternative Name.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="AlternativeName_VersionedChildStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="VersionedChildGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:element name="NamedObjectRef" type="VersionOfObjectRefStructure" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Object for which ALTERNATIVE NAME provides an alias. May be omitted if given by context.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="Lang" type="xsd:language" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Language of the names.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="NameType" type="NameTypeEnumeration" default="alias" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Type of Name - fixed value. Default is Alias.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="TypeOfName" type="xsd:normalizedString" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Type of Nam - open.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="Name" type="MultilingualString">								<xsd:annotation>									<xsd:documentation>Name of the entity.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="ShortName" type="MultilingualString" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Short Name of the entity.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="Abbreviation" type="MultilingualString" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Abbreviation of the entity.</xsd:documentation>								</xsd:annotation>							</xsd:element>							<xsd:element name="QualifierName" type="MultilingualString" minOccurs="0">								<xsd:annotation>									<xsd:documentation>Additional Qualifier of the ENTITY name.</xsd:documentation>								</xsd:annotation>							</xsd:element>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="nameOfClass" type="NameOfClass" use="optional">						<xsd:annotation>							<xsd:documentation>Name of Class of the ENTITY. Allows reflection. Fixed for each ENTITY type.</xsd:documentation>						</xsd:annotation>					</xsd:attribute>					<xsd:attribute name="id" type="AlternativeNameIdType"/>					<xsd:attribute name="dataSourceRef" type="DataSourceIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Name of source of the data.</xsd:documentation>						</xsd:annotation>					</xsd:attribute>					<xsd:attribute name="order" type="xsd:integer">						<xsd:annotation>							<xsd:documentation>Order of name.</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="AlternativeName_VersionedChildStructure">		<xsd:annotation>			<xsd:documentation>Type for ALTERNATIVE NAME.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="VersionedChildStructure">				<xsd:sequence>					<xsd:element name="NamedObjectRef" type="VersionOfObjectRefStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Object for which ALTERNATIVE NAME provides an alias. May be omitted if given by context.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="Lang" type="xsd:language" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Language of the names.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="NameType" type="NameTypeEnumeration" default="alias" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Type of Name - fixed value. Default is Alias.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="TypeOfName" type="xsd:normalizedString" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Type of Nam - open.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="Name" type="MultilingualString">						<xsd:annotation>							<xsd:documentation>Name of the entity.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="ShortName" type="MultilingualString" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Short Name of the entity.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="Abbreviation" type="MultilingualString" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Abbreviation of the entity.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="QualifierName" type="MultilingualString" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Additional Qualifier of the ENTITY name.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>				<xsd:attribute name="order" type="xsd:integer">					<xsd:annotation>						<xsd:documentation>Order of name.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?> 
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_alternativeName_version">
+	<xsd:include schemaLocation="../../netex_framework/netex_responsibility/netex_responsibility_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_alternativeName_support-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2007-03-12</Created>
+				</Date>
+				<Date>
+					<Modified>2011-12-16</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines STOP PLACE path types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_alternativeName_version-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the SIRI standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange -  ALTERNATIVE NAME  Base types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>Basic name types for IFOPT Fixed Objects in Public Transport.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<!-- Simple Type Definitions -->
+	<xsd:complexType name="alternativeNames_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for list of ALTERNATIVE NAMEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="AlternativeName" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>ALTERNATIVE NAME for Element.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="AlternativeName" substitutionGroup="VersionedChild">
+		<xsd:annotation>
+			<xsd:documentation>Alternative Name.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="AlternativeName_VersionedChildStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionedChildGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:element name="NamedObjectRef" type="VersionOfObjectRefStructure" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Object for which ALTERNATIVE NAME provides an alias. May be omitted if given by context.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="Lang" type="xsd:language" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Language of the names.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="NameType" type="NameTypeEnumeration" default="alias" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Type of Name - fixed value. Default is Alias.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="TypeOfName" type="xsd:normalizedString" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Type of Nam - open.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="Name" type="MultilingualString">
+								<xsd:annotation>
+									<xsd:documentation>Name of the entity.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="ShortName" type="MultilingualString" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Short Name of the entity.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="Abbreviation" type="MultilingualString" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Abbreviation of the entity.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="QualifierName" type="MultilingualString" minOccurs="0">
+								<xsd:annotation>
+									<xsd:documentation>Additional Qualifier of the ENTITY name.</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="nameOfClass" type="NameOfClass" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Name of Class of the ENTITY. Allows reflection. Fixed for each ENTITY type.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="id" type="AlternativeNameIdType"/>
+					<xsd:attribute name="dataSourceRef" type="DataSourceIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Name of source of the data.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order" type="xsd:integer">
+						<xsd:annotation>
+							<xsd:documentation>Order of name.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="AlternativeName_VersionedChildStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for ALTERNATIVE NAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:element name="NamedObjectRef" type="VersionOfObjectRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Object for which ALTERNATIVE NAME provides an alias. May be omitted if given by context.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Lang" type="xsd:language" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Language of the names.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="NameType" type="NameTypeEnumeration" default="alias" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Type of Name - fixed value. Default is Alias.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="TypeOfName" type="xsd:normalizedString" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Type of Nam - open.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Name" type="MultilingualString">
+						<xsd:annotation>
+							<xsd:documentation>Name of the entity.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="ShortName" type="MultilingualString" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Short Name of the entity.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Abbreviation" type="MultilingualString" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Abbreviation of the entity.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="QualifierName" type="MultilingualString" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Additional Qualifier of the ENTITY name.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="order" type="xsd:integer">
+					<xsd:annotation>
+						<xsd:documentation>Order of name.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_dayType_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_dayType_support-v1.0.xsd
@@ -1,1 +1,162 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) --><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_dayType_support">	<xsd:include schemaLocation="../netex_responsibility/netex_relationship-v1.0.xsd"/>	<xsd:include schemaLocation="../netex_genericFramework/netex_grouping_support-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2014-03-16</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines DAY TYPE identifier types </p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_dayType_support-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the SIRI standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - Properties OF Day  as types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>NeTEX: DAY TYPE identifier types for NeTEx.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<!-- ====DAY TYPE=================================================== -->	<xsd:complexType name="dayTypeRefs_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a list of DAY TYPEs.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="oneToManyRelationshipStructure">				<xsd:sequence>					<xsd:element ref="DayTypeRef" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:simpleType name="DayTypeIdType">		<xsd:annotation>			<xsd:documentation>Identifier of a DAY TYPE.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:element name="DayTypeRef" type="DayTypeRefStructure" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation>Reference to a DAY TYPE.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="DayTypeRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a DAY TYPE.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="DayTypeIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ==Timeband ========================================================= -->	<xsd:complexType name="timebandRefs_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a list of TIMEBAND.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="oneToManyRelationshipStructure">				<xsd:sequence>					<xsd:element ref="TimebandRef" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:simpleType name="TimebandIdType">		<xsd:annotation>			<xsd:documentation>Identifier of a TIMEBAND.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:element name="TimebandRef" type="TimebandRefStructure" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation>Reference to a TIME BAND.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="TimebandRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a TIMEBAND.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="TimebandIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of TIMEBANd.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ==Timeband ========================================================= -->	<xsd:simpleType name="GroupOfTimebandsIdType">		<xsd:annotation>			<xsd:documentation>Identifier of a GROUP OF TIMEBANDs.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="GroupOfEntitiesIdType"/>	</xsd:simpleType>	<xsd:element name="GroupOfTimebandsRef" type="GroupOfTimebandsRefStructure" substitutionGroup="GroupOfEntitiesRef_">		<xsd:annotation>			<xsd:documentation>Reference to a GROUP OF TIMEBANDs.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="GroupOfTimebandsRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a GROUP OF TIMEBANDs.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="GroupOfEntitiesRefStructure">				<xsd:attribute name="ref" type="GroupOfTimebandsIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of GROUP OF TIMEBANDs.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_dayType_support">
+	<xsd:include schemaLocation="../netex_responsibility/netex_relationship-v1.0.xsd"/>
+	<xsd:include schemaLocation="../netex_genericFramework/netex_grouping_support-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2014-03-16</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines DAY TYPE identifier types </p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_dayType_support-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the SIRI standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - Properties OF Day  as types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEX: DAY TYPE identifier types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<!-- ====DAY TYPE=================================================== -->
+	<xsd:complexType name="dayTypeRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of DAY TYPEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="DayTypeRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="DayTypeIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a DAY TYPE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DayTypeRef" type="DayTypeRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DAY TYPE.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DayTypeRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DAY TYPE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="DayTypeIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced entity.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ==Timeband ========================================================= -->
+	<xsd:complexType name="timebandRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of TIMEBAND.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="TimebandRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="TimebandIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a TIMEBAND.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="TimebandRef" type="TimebandRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a TIME BAND.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="TimebandRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TIMEBAND.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="TimebandIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of TIMEBANd.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ==Timeband ========================================================= -->
+	<xsd:simpleType name="GroupOfTimebandsIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a GROUP OF TIMEBANDs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="GroupOfEntitiesIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="GroupOfTimebandsRef" type="GroupOfTimebandsRefStructure" substitutionGroup="GroupOfEntitiesRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a GROUP OF TIMEBANDs.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="GroupOfTimebandsRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a GROUP OF TIMEBANDs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="GroupOfEntitiesRefStructure">
+				<xsd:attribute name="ref" type="GroupOfTimebandsIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of GROUP OF TIMEBANDs.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_equipment_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_equipment_support-v1.0.xsd
@@ -1,1 +1,225 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) --><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_equipment_support">	<xsd:include schemaLocation="../netex_genericFramework/netex_place_support-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2014-03-16</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines EQUIPMENT identifier types </p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_equipmnet_support-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the SIRI standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - EQUIPMENT types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>NeTEX: EQUIPMENT identifier types for NeTEx.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:simpleType name="EquipmentIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of EQUIPMENT.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:element name="EquipmentRef" type="EquipmentRefStructure">		<xsd:annotation>			<xsd:documentation>Reference to EQUIPMENT.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="EquipmentRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to an EQUIPMENT.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="EquipmentIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of an EQUIPMENT.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="InstalledEquipmentRef" type="InstalledEquipmentRefStructure" abstract="true" substitutionGroup="EquipmentRef">		<xsd:annotation>			<xsd:documentation>Reference to an INSTALLED EQUIPMENT.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="InstalledEquipmentRefStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for a reference to an INSTALLED EQUIPMENT.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="EquipmentRefStructure">				<xsd:attribute name="ref" type="InstalledEquipmentIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a POINT.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="InstalledEquipmentIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of an INSTALLED EQUIPMENT.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="EquipmentIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:simpleType name="TypeOfEquipmentIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of an EQUIPMENT.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="TypeOfValueIdType"/>	</xsd:simpleType>	<xsd:element name="TypeOfEquipmentRef" type="TypeOfEquipmentRefStructure" substitutionGroup="TypeOfEntityRef">		<xsd:annotation>			<xsd:documentation>Reference to a TYPE OF EQUIPMENT.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="TypeOfEquipmentRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a TYPE OF EQUIPMENT.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="TypeOfValueRefStructure">				<xsd:attribute name="ref" type="TypeOfEquipmentIdType" use="required">					<xsd:annotation>						<xsd:documentation>Reference to identifier of a TYPE OF EQUIPMENT.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!--=============================================================================-->	<xsd:simpleType name="EquipmentPositionIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of an EQUIPMENT POSITION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="PlaceIdType"/>	</xsd:simpleType>	<xsd:element name="EquipmentPositionRef" type="EquipmentPositionRefStructure" substitutionGroup="PlaceRef_">		<xsd:annotation>			<xsd:documentation>Reference to an EQUIPMENT POSITION.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="EquipmentPositionRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to an EQUIPMENT POSITION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="PlaceRefStructure">				<xsd:attribute name="ref" type="EquipmentPositionIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of an EQUIPMENT POSITION.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!--=============================================================================-->	<xsd:simpleType name="EquipmentPlaceIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of an EQUIPMENT PLACE.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="PlaceIdType"/>	</xsd:simpleType>	<xsd:element name="EquipmentPlaceRef" type="EquipmentPlaceRefStructure" substitutionGroup="PlaceRef_">		<xsd:annotation>			<xsd:documentation>Reference to an EQUIPMENT PLACE.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="EquipmentPlaceRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to an EQUIPMENT PLACE.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="PlaceRefStructure">				<xsd:attribute name="ref" type="EquipmentPlaceIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of an EQUIPMENT PLACE.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="PassengerEquipmentIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a PASSENGER EQUIPMENT.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="InstalledEquipmentIdType"/>	</xsd:simpleType>	<xsd:element name="PassengerEquipmentRef" type="InstalledEquipmentRefStructure" substitutionGroup="InstalledEquipmentRef">		<xsd:annotation>			<xsd:documentation>Reference to a PASSENGER EQUIPMENT.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="PassengerEquipmentRefStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for a reference to a PASSENGER EQUIPMENT.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="InstalledEquipmentRefStructure">				<xsd:attribute name="ref" type="PassengerEquipmentIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a POINT.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="EquipmentStatusEnumeration">		<xsd:annotation>			<xsd:documentation>Allowed values for status of EQUIPMENT.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN">			<xsd:enumeration value="unknown"/>			<xsd:enumeration value="available"/>			<xsd:enumeration value="notAvailable"/>		</xsd:restriction>	</xsd:simpleType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_equipment_support">
+	<xsd:include schemaLocation="../netex_genericFramework/netex_place_support-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2014-03-16</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines EQUIPMENT identifier types </p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_equipmnet_support-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the SIRI standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - EQUIPMENT types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NeTEX: EQUIPMENT identifier types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="EquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="EquipmentRef" type="EquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Reference to EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="EquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="EquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of an EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="InstalledEquipmentRef" type="InstalledEquipmentRefStructure" abstract="true" substitutionGroup="EquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an INSTALLED EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="InstalledEquipmentRefStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an INSTALLED EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="EquipmentRefStructure">
+				<xsd:attribute name="ref" type="InstalledEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a POINT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="InstalledEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of an INSTALLED EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="EquipmentIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="TypeOfEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of an EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TypeOfValueIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="TypeOfEquipmentRef" type="TypeOfEquipmentRefStructure" substitutionGroup="TypeOfEntityRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a TYPE OF EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="TypeOfEquipmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TYPE OF EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="TypeOfValueRefStructure">
+				<xsd:attribute name="ref" type="TypeOfEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Reference to identifier of a TYPE OF EQUIPMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--=============================================================================-->
+	<xsd:simpleType name="EquipmentPositionIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of an EQUIPMENT POSITION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="PlaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="EquipmentPositionRef" type="EquipmentPositionRefStructure" substitutionGroup="PlaceRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an EQUIPMENT POSITION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="EquipmentPositionRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an EQUIPMENT POSITION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="PlaceRefStructure">
+				<xsd:attribute name="ref" type="EquipmentPositionIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of an EQUIPMENT POSITION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--=============================================================================-->
+	<xsd:simpleType name="EquipmentPlaceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of an EQUIPMENT PLACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="PlaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="EquipmentPlaceRef" type="EquipmentPlaceRefStructure" substitutionGroup="PlaceRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an EQUIPMENT PLACE.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="EquipmentPlaceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an EQUIPMENT PLACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="PlaceRefStructure">
+				<xsd:attribute name="ref" type="EquipmentPlaceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of an EQUIPMENT PLACE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="PassengerEquipmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PASSENGER EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="InstalledEquipmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PassengerEquipmentRef" type="InstalledEquipmentRefStructure" substitutionGroup="InstalledEquipmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PASSENGER EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PassengerEquipmentRefStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a PASSENGER EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="InstalledEquipmentRefStructure">
+				<xsd:attribute name="ref" type="PassengerEquipmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a POINT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="EquipmentStatusEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for status of EQUIPMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="unknown"/>
+			<xsd:enumeration value="available"/>
+			<xsd:enumeration value="notAvailable"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_reusableComponents/netex_serviceCalendar_support-v1.0.xsd
@@ -1,1 +1,159 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) --><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_serviceCalendar_support">	<xsd:include schemaLocation="../netex_genericFramework/netex_assignment_support-v1.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2014-03-31</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines  SERVICE CALENDAR identifier  types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_schematicMap_version-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the SIRI standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - SERVICE CALENDAR identifier  types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>NetEX:SERVICE CALENDAR identifier  types for NeTEx Network Exchange.</xsd:documentation>	</xsd:annotation>	<!-- ====Calendar====================================================== -->	<xsd:simpleType name="ServiceCalendarIdType">		<xsd:annotation>			<xsd:documentation>Identifier of a SERVICE CALENDAR.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:element name="ServiceCalendarRef" type="ServiceCalendarRefStructure" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation> Reference to a SERVICE CALENDAR.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ServiceCalendarRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SERVICE CALENDAR.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="ServiceCalendarIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a SERVICE CALENDAR.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="OperatingDayIdType">		<xsd:annotation>			<xsd:documentation>Identifier of an OPERATING DAY.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:element name="OperatingDayRef" type="OperatingDayRefStructure" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation>Reference to an OPERATING DAY.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="OperatingDayRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to an OPERATING DAY.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="OperatingDayIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of an OPERATING DAY.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="OperatingPeriodIdType">		<xsd:annotation>			<xsd:documentation>Identifier of an OPERATING PERIOD.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:element name="OperatingPeriodRef" type="OperatingPeriodRefStructure" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation>Reference to an OPERATING PERIOD.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="OperatingPeriodRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to an OPERATING PERIOD.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="OperatingPeriodIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of an OPERATING PERIOD.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="DayTypeAssignmentIdType">		<xsd:annotation>			<xsd:documentation>Identifier of a  DAY TYPE ASSIGNMENT.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="AssignmentIdType"/>	</xsd:simpleType>	<xsd:element name="DayTypeAssignmentRef" type="DayTypeAssignmentRefStructure" substitutionGroup="AssignmentRef">		<xsd:annotation>			<xsd:documentation>Reference to a DAY TYPE ASSIGNMENT.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="DayTypeAssignmentRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a DAY TYPE ASSIGNMENT.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="AssignmentRefStructure">				<xsd:attribute name="ref" type="DayTypeAssignmentIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a DAY TYPE ASSIGNMENT.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by christophe duquesne (Dryade SARL) -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_serviceCalendar_support">
+	<xsd:include schemaLocation="../netex_genericFramework/netex_assignment_support-v1.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2014-03-31</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines  SERVICE CALENDAR identifier  types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_reusableComponents}netex_schematicMap_version-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the SIRI standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - SERVICE CALENDAR identifier  types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>NetEX:SERVICE CALENDAR identifier  types for NeTEx Network Exchange.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ====Calendar====================================================== -->
+	<xsd:simpleType name="ServiceCalendarIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a SERVICE CALENDAR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="ServiceCalendarRef" type="ServiceCalendarRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation> Reference to a SERVICE CALENDAR.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ServiceCalendarRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SERVICE CALENDAR.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="ServiceCalendarIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SERVICE CALENDAR.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="OperatingDayIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of an OPERATING DAY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="OperatingDayRef" type="OperatingDayRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an OPERATING DAY.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="OperatingDayRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an OPERATING DAY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="OperatingDayIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of an OPERATING DAY.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="OperatingPeriodIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of an OPERATING PERIOD.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="OperatingPeriodRef" type="OperatingPeriodRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to an OPERATING PERIOD.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="OperatingPeriodRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to an OPERATING PERIOD.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="OperatingPeriodIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of an OPERATING PERIOD.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="DayTypeAssignmentIdType">
+		<xsd:annotation>
+			<xsd:documentation>Identifier of a  DAY TYPE ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AssignmentIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="DayTypeAssignmentRef" type="DayTypeAssignmentRefStructure" substitutionGroup="AssignmentRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a DAY TYPE ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="DayTypeAssignmentRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a DAY TYPE ASSIGNMENT.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AssignmentRefStructure">
+				<xsd:attribute name="ref" type="DayTypeAssignmentIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a DAY TYPE ASSIGNMENT.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/schema/1.03/xsd/netex_framework/netex_utility/netex_utility_xml-v1.0.xsd
+++ b/schema/1.03/xsd/netex_framework/netex_utility/netex_utility_xml-v1.0.xsd
@@ -1,1 +1,104 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_utility_xml">	<!-- ================================== -->	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor> CEN TC278 WG3 SG9Team</Contributor>				<Coverage>Europe</Coverage>				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Modified>2010-09-307</Modified>				</Date>				<Date>					<Created>2010-04-17</Created>				</Date>				<Description>					<p>netex is a European CEN standard for the exchange of real time information . This subschema defines common request processing elements</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_utility}netex_utility_xml-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>				<Relation>					 				</Relation>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the VDV, RTIGXML and Trident standards.</li>					</ul>				</Source>				<Status>1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx XML schema. Shared Utility elements. </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>Xml utility types for NeTEX</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:complexType name="MultilingualString">		<xsd:annotation>			<xsd:documentation>Type for a string in a specified language.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="xsd:normalizedString">				<xsd:attribute name="lang" type="xsd:language">					<xsd:annotation>						<xsd:documentation>Language of string contents.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>				<xsd:attribute name="textIdType" type="xsd:normalizedString">					<xsd:annotation>						<xsd:documentation>Resource id of string.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:extension>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="EmptyType">		<xsd:annotation>			<xsd:documentation>A type with no allowed content, used when simply the presence of an element is significant.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:string">			<xsd:enumeration value=""/>		</xsd:restriction>	</xsd:simpleType>	<xsd:element name="Extensions" type="ExtensionsStructure">		<xsd:annotation>			<xsd:documentation>User defined Extensions to ENTITY in schema. (Wrapper tag used to avoid problems with handling of optional 'any' by some validators).</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ExtensionsStructure">		<xsd:annotation>			<xsd:documentation>Type for Extensions to schema. Wraps an 'any' tag to ensure decidability.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded">				<xsd:annotation>					<xsd:documentation>Placeholder for user extensions.</xsd:documentation>				</xsd:annotation>			</xsd:any>		</xsd:sequence>	</xsd:complexType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_utility_xml">
+	<!-- ================================== -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor> CEN TC278 WG3 SG9Team</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First Drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Modified>2010-09-307</Modified>
+				</Date>
+				<Date>
+					<Created>2010-04-17</Created>
+				</Date>
+				<Description>
+					<p>netex is a European CEN standard for the exchange of real time information . This subschema defines common request processing elements</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_framework/netex_utility}netex_utility_xml-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX </Publisher>
+				<Relation>
+					 
+				</Relation>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the VDV, RTIGXML and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx XML schema. Shared Utility elements. </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>Xml utility types for NeTEX</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="MultilingualString">
+		<xsd:annotation>
+			<xsd:documentation>Type for a string in a specified language.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:normalizedString">
+				<xsd:attribute name="lang" type="xsd:language">
+					<xsd:annotation>
+						<xsd:documentation>Language of string contents.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="textIdType" type="xsd:normalizedString">
+					<xsd:annotation>
+						<xsd:documentation>Resource id of string.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="EmptyType">
+		<xsd:annotation>
+			<xsd:documentation>A type with no allowed content, used when simply the presence of an element is significant.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value=""/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="Extensions" type="ExtensionsStructure">
+		<xsd:annotation>
+			<xsd:documentation>User defined Extensions to ENTITY in schema. (Wrapper tag used to avoid problems with handling of optional 'any' by some validators).</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ExtensionsStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Extensions to schema. Wraps an 'any' tag to ensure decidability.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Placeholder for user extensions.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:any>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/schema/1.03/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAll-v1.0.xsd
+++ b/schema/1.03/xsd/netex_part_1/part1_ifopt/netex_ifopt_equipmentAll-v1.0.xsd
@@ -1,1 +1,153 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2009 sp1 (http://www.altova.com) by Nicholas Knowles (Kizoom) --><!-- 2007 03 23 Add repeating name --><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_ifopt_equipmentAll">	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor>V1.0 Nicholas Knowles</Contributor>				<Contributor>Roger Slevin [Roger.Slevin@dft.gsi.gov.uk]</Contributor>				<Coverage>Europe</Coverage>				<Creator>Created as W3C .xsd schema by Nicholas Knowles. as 1.0 XML schema </Creator>				<Date>					<Created>2007-06-10</Created>				</Date>				<Date>					<Modified>2007-06-22</Modified>				</Date>				<Description>					<p>Equipment types </p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_Ifopt_equipmentAll-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>CEN TC278 SG6 and Department for Transport, Great Minster House, 76 Marsham Street, London SW1P 4DR</Publisher>				<Relation>					<Requires>http://www.netex.org.uk/schemas/1.0/ifopt/netex_ifopt_xxxxx-v1.0.xsd</Requires>				</Relation>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Evolved from NaPTAN, SIRI and other schemas.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange (IFOPT subset) - All EQIPMENT types. </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>All EQIPMENT types. NeTEx.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<!--.....These are the actual dependencies...-->	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_equipment_version-v1.0.xsd"/>	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentSigns_support-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentSigns_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentAccess_support-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentAccess_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentWaiting_support-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentWaiting_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentTicketing_support-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentTicketing_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentParking_support-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentParking_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentPassenger_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_equipmentPassenger_version-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_localService_support-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_localService_version-v1.0.xsd"/>		<xsd:include schemaLocation="netex_ifopt_localServiceCommercial_support-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_localServiceCommercial_version-v1.0.xsd"/>	<!-- ======================================================================= -->	<xsd:group name="AllEquipmentGroup">		<xsd:annotation>			<xsd:documentation>EQUIPMENT elements.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="equipmentPlaces" type="equipmentPlaces_RelStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>EQUIPMENT PLACEs within SITE COMPONENT.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="placeEquipments" type="placeEquipments_RelStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Items of fixed EQUIPMENT that may be located in places within the SITE  ELEMENT.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="localServices" type="localServices_RelStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>LOCAL SERVICEs that may be located in PLACEs within the SITE ELEMENT.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= -->	<xsd:complexType name="explicitEquipments_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a list of LOCAL SERVICEs.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="containmentAggregationStructure">				<xsd:choice maxOccurs="unbounded">					<xsd:element ref="InstalledEquipmentRef"/>					<xsd:element ref="InstalledEquipment"/>					<xsd:element ref="LocalServiceRef"/>					<xsd:element ref="LocalService"/>					<xsd:element ref="OtherPlaceEquipment"/>				</xsd:choice>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:complexType name="explicitPlaceEquipments_RelStructure">		<xsd:annotation>			<xsd:documentation>Items of fixed EQUIPMENT that may be located in places within the STOP PLACE.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="containmentAggregationStructure">				<xsd:choice minOccurs="0" maxOccurs="unbounded">					<xsd:element ref="OtherPlaceEquipment" minOccurs="0"/>					<xsd:group ref="AccessEquipmentChoice" minOccurs="0"/>					<xsd:group ref="SignEquipmentChoice" minOccurs="0"/>					<xsd:group ref="PassengerEquipmentChoice" minOccurs="0"/>					<xsd:group ref="TicketingEquipmentChoice" minOccurs="0"/>				</xsd:choice>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:complexType name="explicitLocalServices_RelStructure">		<xsd:annotation>			<xsd:documentation>Items of LOCAL SERVICE EQUIPMENT that may be located in PLACEs within the SITE.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="containmentAggregationStructure">				<xsd:choice maxOccurs="unbounded">					<xsd:element ref="LocalServiceRef"/>					<xsd:element ref="LocalService" maxOccurs="1"/>				</xsd:choice>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2009 sp1 (http://www.altova.com) by Nicholas Knowles (Kizoom) -->
+<!-- 2007 03 23 Add repeating name -->
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_ifopt_equipmentAll">
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>V1.0 Nicholas Knowles</Contributor>
+				<Contributor>Roger Slevin [Roger.Slevin@dft.gsi.gov.uk]</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>Created as W3C .xsd schema by Nicholas Knowles. as 1.0 XML schema </Creator>
+				<Date>
+					<Created>2007-06-10</Created>
+				</Date>
+				<Date>
+					<Modified>2007-06-22</Modified>
+				</Date>
+				<Description>
+					<p>Equipment types
+
+ </p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_Ifopt_equipmentAll-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>CEN TC278 SG6 and Department for Transport, Great Minster House, 76 Marsham Street, London SW1P 4DR</Publisher>
+				<Relation>
+					<Requires>http://www.netex.org.uk/schemas/1.0/ifopt/netex_ifopt_xxxxx-v1.0.xsd</Requires>
+				</Relation>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Evolved from NaPTAN, SIRI and other schemas.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange (IFOPT subset) - All EQIPMENT types. </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>All EQIPMENT types. NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<!--.....These are the actual dependencies...-->
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_equipment_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_reusableComponents/netex_equipmentVehiclePassenger_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentSigns_support-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentSigns_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentAccess_support-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentAccess_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentWaiting_support-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentWaiting_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentTicketing_support-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentTicketing_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentParking_support-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentParking_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentPassenger_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_equipmentPassenger_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_localService_support-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_localService_version-v1.0.xsd"/>
+		<xsd:include schemaLocation="netex_ifopt_localServiceCommercial_support-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_localServiceCommercial_version-v1.0.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:group name="AllEquipmentGroup">
+		<xsd:annotation>
+			<xsd:documentation>EQUIPMENT elements.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="equipmentPlaces" type="equipmentPlaces_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>EQUIPMENT PLACEs within SITE COMPONENT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="placeEquipments" type="placeEquipments_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Items of fixed EQUIPMENT that may be located in places within the SITE  ELEMENT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="localServices" type="localServices_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>LOCAL SERVICEs that may be located in PLACEs within the SITE ELEMENT.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="explicitEquipments_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of LOCAL SERVICEs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="InstalledEquipmentRef"/>
+					<xsd:element ref="InstalledEquipment"/>
+					<xsd:element ref="LocalServiceRef"/>
+					<xsd:element ref="LocalService"/>
+					<xsd:element ref="OtherPlaceEquipment"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="explicitPlaceEquipments_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Items of fixed EQUIPMENT that may be located in places within the STOP PLACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice minOccurs="0" maxOccurs="unbounded">
+					<xsd:element ref="OtherPlaceEquipment" minOccurs="0"/>
+					<xsd:group ref="AccessEquipmentChoice" minOccurs="0"/>
+					<xsd:group ref="SignEquipmentChoice" minOccurs="0"/>
+					<xsd:group ref="PassengerEquipmentChoice" minOccurs="0"/>
+					<xsd:group ref="TicketingEquipmentChoice" minOccurs="0"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="explicitLocalServices_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Items of LOCAL SERVICE EQUIPMENT that may be located in PLACEs within the SITE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="containmentAggregationStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="LocalServiceRef"/>
+					<xsd:element ref="LocalService" maxOccurs="1"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_part_1/part1_ifopt/netex_ifopt_flexibleStopPlace_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_part_1/part1_ifopt/netex_ifopt_flexibleStopPlace_support-v1.0.xsd
@@ -1,1 +1,176 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="inetex_ifopt_flexibleStopPlace_support">	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_place_support-v1.0.xsd"/>	<!-- ======================================================================= -->	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2011-12-16</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines STOP PLACE base types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_ifopt_flexibleStopPlace_support-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the SIRI standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - FLEXIBLE STOP PLACE Base types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>FLEXIBLE STOP PLACE types for IFOPT Fixed Objects in Public Transport.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<!-- Simple Type Definitions -->	<xsd:simpleType name="FlexibleStopPlaceIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a FLEXIBLE STOP PLACE.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="PlaceIdType"/>	</xsd:simpleType>	<xsd:element name="FlexibleStopPlaceRef" type="FlexibleStopPlaceRefStructure" substitutionGroup="PlaceRef_">		<xsd:annotation>			<xsd:documentation>Reference to a FLEXIBLE STOP PLACE.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="FlexibleStopPlaceRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a FLEXIBLE STOP PLACE.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="PlaceRefStructure">				<xsd:attribute name="ref" type="FlexibleStopPlaceIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a FLEXIBLE STOP PLACE.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:complexType name="flexibleStopPlaceRefs_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a collection of one or more references to a FLEXIBLE STOP PLACE.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="oneToManyRelationshipStructure">				<xsd:sequence>					<xsd:element ref="FlexibleStopPlaceRef" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="FlexibleQuayIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a FLEXIBLE QUAY.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="PlaceIdType"/>	</xsd:simpleType>	<xsd:element name="FlexibleQuayRef" type="FlexibleQuayRefStructure" substitutionGroup="PlaceRef_">		<xsd:annotation>			<xsd:documentation>Reference to a FLEXIBLE QUAY.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="FlexibleQuayRefStructure">		<xsd:annotation>			<xsd:documentation>Type for reference to a FLEXIBLE QUAY.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="PlaceRefStructure">				<xsd:attribute name="ref" type="FlexibleQuayIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a FLIEXIBLE QUAY.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="FlexibleAreaIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a FLEXIBLE AREA.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="FlexibleQuayIdType"/>	</xsd:simpleType>	<xsd:element name="FlexibleAreaRef" type="FlexibleAreaRefStructure" substitutionGroup="FlexibleQuayRef">		<xsd:annotation>			<xsd:documentation>Reference to a FLEXIBLE AREA.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="FlexibleAreaRefStructure">		<xsd:annotation>			<xsd:documentation>Type for reference to a FLEXIBLE AREA.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="FlexibleQuayRefStructure">				<xsd:attribute name="ref" type="FlexibleAreaIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a FLEXIBLE AREa.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="HailAndRideAreaIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a HAIL AND RIDE AREA.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="FlexibleQuayIdType"/>	</xsd:simpleType>	<xsd:element name="HailAndRideAreaRef" type="HailAndRideAreaRefStructure" substitutionGroup="FlexibleQuayRef">		<xsd:annotation>			<xsd:documentation>Reference to a HAIL AND RIDE AREA.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="HailAndRideAreaRefStructure">		<xsd:annotation>			<xsd:documentation>Type for Unique Reference to a HAIL AND RIDE AREA.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="FlexibleQuayRefStructure">				<xsd:attribute name="ref" type="HailAndRideAreaIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a HAIL AND RIDE AREA.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="inetex_ifopt_flexibleStopPlace_support">
+	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_place_support-v1.0.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2011-12-16</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines STOP PLACE base types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_ifopt_flexibleStopPlace_support-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the SIRI standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - FLEXIBLE STOP PLACE Base types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>FLEXIBLE STOP PLACE types for IFOPT Fixed Objects in Public Transport.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<!-- Simple Type Definitions -->
+	<xsd:simpleType name="FlexibleStopPlaceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a FLEXIBLE STOP PLACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="PlaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="FlexibleStopPlaceRef" type="FlexibleStopPlaceRefStructure" substitutionGroup="PlaceRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a FLEXIBLE STOP PLACE.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="FlexibleStopPlaceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a FLEXIBLE STOP PLACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="PlaceRefStructure">
+				<xsd:attribute name="ref" type="FlexibleStopPlaceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a FLEXIBLE STOP PLACE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="flexibleStopPlaceRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a collection of one or more references to a FLEXIBLE STOP PLACE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="FlexibleStopPlaceRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="FlexibleQuayIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a FLEXIBLE QUAY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="PlaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="FlexibleQuayRef" type="FlexibleQuayRefStructure" substitutionGroup="PlaceRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a FLEXIBLE QUAY.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="FlexibleQuayRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for reference to a FLEXIBLE QUAY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="PlaceRefStructure">
+				<xsd:attribute name="ref" type="FlexibleQuayIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a FLIEXIBLE QUAY.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="FlexibleAreaIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a FLEXIBLE AREA.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="FlexibleQuayIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="FlexibleAreaRef" type="FlexibleAreaRefStructure" substitutionGroup="FlexibleQuayRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a FLEXIBLE AREA.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="FlexibleAreaRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for reference to a FLEXIBLE AREA.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="FlexibleQuayRefStructure">
+				<xsd:attribute name="ref" type="FlexibleAreaIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a FLEXIBLE AREa.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="HailAndRideAreaIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a HAIL AND RIDE AREA.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="FlexibleQuayIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="HailAndRideAreaRef" type="HailAndRideAreaRefStructure" substitutionGroup="FlexibleQuayRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a HAIL AND RIDE AREA.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="HailAndRideAreaRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Unique Reference to a HAIL AND RIDE AREA.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="FlexibleQuayRefStructure">
+				<xsd:attribute name="ref" type="HailAndRideAreaIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a HAIL AND RIDE AREA.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_part_1/part1_ifopt/netex_ifopt_path_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_part_1/part1_ifopt/netex_ifopt_path_support-v1.0.xsd
@@ -1,1 +1,310 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_ifopt_path_support">	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_pointAndLinkSequence_support-v1.0.xsd"/>	<xsd:include schemaLocation="netex_ifopt_site_support-v1.0.xsd"/>	<!-- ======================================================================= -->	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2007-03-12</Created>				</Date>				<Date>					<Modified>2011-12-16</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines PATH types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_ifopt_path_support-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the SIRI standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - PATH identifier types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>PATH identifier types for IFOPT Fixed Objects in Public Transport.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:complexType name="pathLinkRefs_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a list of references to a PATH LINK.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="oneToManyRelationshipStructure">				<xsd:choice maxOccurs="unbounded">					<xsd:element ref="PathLinkRef"/>					<xsd:element ref="PathLinkRefByValue"/>				</xsd:choice>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:simpleType name="PathLinkIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a PATH LINK.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="LinkIdType"/>	</xsd:simpleType>	<xsd:element name="PathLinkRef" type="PathLinkRefStructure" substitutionGroup="LinkRef">		<xsd:annotation>			<xsd:documentation>Reference to a PATH LINK.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="PathLinkRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a PATH LINK.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="LinkRefStructure">				<xsd:attribute name="ref" type="PathLinkIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a PATH LINK.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="PathLinkRefByValue" type="PathLinkRefByValueStructure" substitutionGroup="LinkRefByValue">		<xsd:annotation>			<xsd:documentation>Reference to a PATH LINK BY VALUE.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="PathLinkRefByValueStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a PATH LINK BY VALUE.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:restriction base="LinkRefByValueStructure">				<xsd:attribute name="fromPointRef" type="PointIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a POINT. at which LINK starts.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>				<xsd:attribute name="toPointRef" type="PointIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a POINT. at which LINK ends.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>				<xsd:attribute name="nameOfPointRefClass" type="NameOfClass" use="optional" fixed="PathPoint">					<xsd:annotation>						<xsd:documentation>Class of POINT referenced by LINK.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="PathJunctionIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a PATH JUNCTION.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="PlaceIdType"/>	</xsd:simpleType>	<xsd:element name="PathJunctionRef" type="PathJunctionRefStructure" substitutionGroup="PlaceRef_">		<xsd:annotation>			<xsd:documentation>Reference to a PATH JUNCTION.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="PathJunctionRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a PATH JUNCTION.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="PlaceRefStructure">				<xsd:attribute name="ref" type="PathJunctionIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a PATH JUNCTION.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<!-- Simple Type Definitions -->	<!-- ======================================================================= -->	<xsd:complexType name="navigationPathRefs_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a list of references to a NAVIGATION PATH.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="oneToManyRelationshipStructure">				<xsd:sequence>					<xsd:element ref="NavigationPathRef" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:simpleType name="NavigationPathIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a NAVIGATION PATH.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="LinkSequenceIdType"/>	</xsd:simpleType>	<xsd:element name="NavigationPathRef" type="NavigationPathRefStructure" substitutionGroup="LinkSequenceRef">		<xsd:annotation>			<xsd:documentation>Reference to a NAVIGATION PATH.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="NavigationPathRefStructure">		<xsd:annotation>			<xsd:documentation>Type for reference to a NAVIGATION PATH.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="LinkSequenceRefStructure">				<xsd:attribute name="ref" type="NavigationPathIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a NAVIGATION PATH.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="AccessSummaryIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a NAVIGATION PATH.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:simpleType name="PathDirectionEnumeration">		<xsd:annotation>			<xsd:documentation>Allowed values for flow direction.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN">			<xsd:enumeration value="oneWay"/>			<xsd:enumeration value="twoWay"/>		</xsd:restriction>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:simpleType name="TransitionEnumeration">		<xsd:annotation>			<xsd:documentation>Allowed values for path transition.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN">			<xsd:enumeration value="up"/>			<xsd:enumeration value="down"/>			<xsd:enumeration value="level"/>			<xsd:enumeration value="upAndDown"/>			<xsd:enumeration value="downAndUp"/>		</xsd:restriction>	</xsd:simpleType>	<xsd:simpleType name="PathHeadingEnumeration">		<xsd:annotation>			<xsd:documentation>Allowed values for path heading.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN">			<xsd:enumeration value="left"/>			<xsd:enumeration value="right"/>			<xsd:enumeration value="forward"/>			<xsd:enumeration value="back"/>		</xsd:restriction>	</xsd:simpleType>	<xsd:simpleType name="NavigationTypeEnumeration">		<xsd:annotation>			<xsd:documentation>Allowed values for Navigation type.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN">			<xsd:enumeration value="hallToQuay"/>			<xsd:enumeration value="hallToStreet"/>			<xsd:enumeration value="quayToHall"/>			<xsd:enumeration value="quayToQuay"/>			<xsd:enumeration value="quayToStreet"/>			<xsd:enumeration value="streetToHall"/>			<xsd:enumeration value="streetToQuay"/>			<xsd:enumeration value="streetToSpace"/>			<xsd:enumeration value="spaceToStreet"/>			<xsd:enumeration value="spaceToHall"/>			<xsd:enumeration value="hallToSpace"/>			<xsd:enumeration value="spaceToSpace"/>			<xsd:enumeration value="other"/>		</xsd:restriction>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:simpleType name="PlaceInSequenceIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of place step in a NAVIGATION PATH.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="PointInSequenceIdType"/>	</xsd:simpleType>	<xsd:element name="PlaceInSequenceRef" type="PlaceInSequenceRefStructure" substitutionGroup="PointInSequenceRef">		<xsd:annotation>			<xsd:documentation>Reference to a PLACE IN SEQUENCE. If given by context does not need to be stated.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="PlaceInSequenceRefStructure">		<xsd:annotation>			<xsd:documentation>Type for reference to a PLACE IN SEQUENCE.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="PointInSequenceRefStructure">				<xsd:attribute name="ref" type="PlaceInSequenceIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a PLACE IN SEQUENCE.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="PathLinkInSequenceIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of link step in a PATH LINK IN SEQUENCE.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="LinkInSequenceIdType"/>	</xsd:simpleType>	<xsd:element name="PathLinkInSequenceRef" type="PathLinkInSequenceRefStructure" substitutionGroup="LinkInSequenceRef">		<xsd:annotation>			<xsd:documentation>Reference to a PATH LINK IN SEQUENCE. If given by context does not need to be stated.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="PathLinkInSequenceRefStructure">		<xsd:annotation>			<xsd:documentation>Type for Reference to a PATH LINK IN SEQUENCE.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="LinkInSequenceRefStructure">				<xsd:attribute name="ref" type="PathLinkInSequenceIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a PATH LINK IN SEQUENCE.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="PathLinkViewIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a PATH LINK VIEW></xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_ifopt_path_support">
+	<xsd:include schemaLocation="../../netex_framework/netex_genericFramework/netex_pointAndLinkSequence_support-v1.0.xsd"/>
+	<xsd:include schemaLocation="netex_ifopt_site_support-v1.0.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2007-03-12</Created>
+				</Date>
+				<Date>
+					<Modified>2011-12-16</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines PATH types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_ifopt_path_support-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the SIRI standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - PATH identifier types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>PATH identifier types for IFOPT Fixed Objects in Public Transport.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="pathLinkRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of references to a PATH LINK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="PathLinkRef"/>
+					<xsd:element ref="PathLinkRefByValue"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="PathLinkIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PATH LINK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="LinkIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PathLinkRef" type="PathLinkRefStructure" substitutionGroup="LinkRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PATH LINK.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PathLinkRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a PATH LINK.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="LinkRefStructure">
+				<xsd:attribute name="ref" type="PathLinkIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PATH LINK.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="PathLinkRefByValue" type="PathLinkRefByValueStructure" substitutionGroup="LinkRefByValue">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PATH LINK BY VALUE.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PathLinkRefByValueStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a PATH LINK BY VALUE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:restriction base="LinkRefByValueStructure">
+				<xsd:attribute name="fromPointRef" type="PointIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a POINT. at which LINK starts.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="toPointRef" type="PointIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a POINT. at which LINK ends.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="nameOfPointRefClass" type="NameOfClass" use="optional" fixed="PathPoint">
+					<xsd:annotation>
+						<xsd:documentation>Class of POINT referenced by LINK.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="PathJunctionIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PATH JUNCTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="PlaceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PathJunctionRef" type="PathJunctionRefStructure" substitutionGroup="PlaceRef_">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PATH JUNCTION.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PathJunctionRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a PATH JUNCTION.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="PlaceRefStructure">
+				<xsd:attribute name="ref" type="PathJunctionIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PATH JUNCTION.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<!-- Simple Type Definitions -->
+	<!-- ======================================================================= -->
+	<xsd:complexType name="navigationPathRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of references to a NAVIGATION PATH.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="NavigationPathRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="NavigationPathIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a NAVIGATION PATH.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="LinkSequenceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="NavigationPathRef" type="NavigationPathRefStructure" substitutionGroup="LinkSequenceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a NAVIGATION PATH.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="NavigationPathRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for reference to a NAVIGATION PATH.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="LinkSequenceRefStructure">
+				<xsd:attribute name="ref" type="NavigationPathIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a NAVIGATION PATH.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="AccessSummaryIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a NAVIGATION PATH.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="PathDirectionEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for flow direction.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="oneWay"/>
+			<xsd:enumeration value="twoWay"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="TransitionEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for path transition.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="up"/>
+			<xsd:enumeration value="down"/>
+			<xsd:enumeration value="level"/>
+			<xsd:enumeration value="upAndDown"/>
+			<xsd:enumeration value="downAndUp"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="PathHeadingEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for path heading.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="left"/>
+			<xsd:enumeration value="right"/>
+			<xsd:enumeration value="forward"/>
+			<xsd:enumeration value="back"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="NavigationTypeEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Allowed values for Navigation type.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="hallToQuay"/>
+			<xsd:enumeration value="hallToStreet"/>
+			<xsd:enumeration value="quayToHall"/>
+			<xsd:enumeration value="quayToQuay"/>
+			<xsd:enumeration value="quayToStreet"/>
+			<xsd:enumeration value="streetToHall"/>
+			<xsd:enumeration value="streetToQuay"/>
+			<xsd:enumeration value="streetToSpace"/>
+			<xsd:enumeration value="spaceToStreet"/>
+			<xsd:enumeration value="spaceToHall"/>
+			<xsd:enumeration value="hallToSpace"/>
+			<xsd:enumeration value="spaceToSpace"/>
+			<xsd:enumeration value="other"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="PlaceInSequenceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of place step in a NAVIGATION PATH.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="PointInSequenceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PlaceInSequenceRef" type="PlaceInSequenceRefStructure" substitutionGroup="PointInSequenceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PLACE IN SEQUENCE. If given by context does not need to be stated.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PlaceInSequenceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for reference to a PLACE IN SEQUENCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="PointInSequenceRefStructure">
+				<xsd:attribute name="ref" type="PlaceInSequenceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PLACE IN SEQUENCE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="PathLinkInSequenceIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of link step in a PATH LINK IN SEQUENCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="LinkInSequenceIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="PathLinkInSequenceRef" type="PathLinkInSequenceRefStructure" substitutionGroup="LinkInSequenceRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a PATH LINK IN SEQUENCE. If given by context does not need to be stated.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="PathLinkInSequenceRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Reference to a PATH LINK IN SEQUENCE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="LinkInSequenceRefStructure">
+				<xsd:attribute name="ref" type="PathLinkInSequenceIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a PATH LINK IN SEQUENCE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="PathLinkViewIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PATH LINK VIEW></xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+</xsd:schema>

--- a/schema/1.03/xsd/netex_part_1/part1_ifopt/netex_ifopt_serviceFeature_support-v1.0.xsd
+++ b/schema/1.03/xsd/netex_part_1/part1_ifopt/netex_ifopt_serviceFeature_support-v1.0.xsd
@@ -1,1 +1,99 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_ifopt_serviceFeature">	<xsd:include schemaLocation="../../netex_framework/netex_responsibility/netex_relationship-v1.0.xsd"/>	<!--===== ========================================================-->	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>				<Date>					<Created>2010-09-04</Created>				</Date>				<Date>					<Modified>2011-02-05</Modified>				</Date>				<Date>					<Modified>2007-03-22</Modified>				</Date>				<Date>					<Modified>2007-06-12</Modified>				</Date>				<Description>					<p>NeTEx - Network Exchange. This subschema defines common SERVICE FEATURE  types.</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_ifopt_serviceFeature-v1.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>				<Rights>Unclassified <Copyright>CEN, Crown Copyright 2009-2014</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the SIRI standards.</li>					</ul>				</Source>				<Status>Version 1.0 Draft for approval</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,Rail transport, Roads and Road transport</Category>					<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>NeTEx Network Exchange - FEATURE types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SERVICE FEATURE identifier types for NeTEx.</xsd:documentation>	</xsd:annotation>	<!--===== ========================================================-->	<xsd:simpleType name="TypeOfServiceFeatureIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a TYPE OF SERVICE FEATURE.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="TypeOfValueIdType"/>	</xsd:simpleType>	<xsd:element name="TypeOfServiceFeatureRef" type="TypeOfServiceFeatureRefStructure" substitutionGroup="TypeOfEntityRef">		<xsd:annotation>			<xsd:documentation>Reference to a TYPE OF SERVICE FEATURE.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="TypeOfServiceFeatureRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a TYPE OF SERVICE FEATURE.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="TypeOfValueRefStructure">				<xsd:attribute name="ref" type="TypeOfServiceFeatureIdType" use="required">					<xsd:annotation>						<xsd:documentation>Reference to a TYPE OF Service FEATURE.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:complexType name="typeOfServiceFeatureRefs_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a list of references to a TYPEs of SERVICE FEATURE.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="oneToManyRelationshipStructure">				<xsd:sequence>					<xsd:element ref="TypeOfServiceFeatureRef" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex" xmlns:siri="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_ifopt_serviceFeature">
+	<xsd:include schemaLocation="../../netex_framework/netex_responsibility/netex_relationship-v1.0.xsd"/>
+	<!--===== ========================================================-->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG6 Editor Nicholas Knowles.  mailto:schemer@netex.org.uk</Creator>
+				<Date>
+					<Created>2010-09-04</Created>
+				</Date>
+				<Date>
+					<Modified>2011-02-05</Modified>
+				</Date>
+				<Date>
+					<Modified>2007-03-22</Modified>
+				</Date>
+				<Date>
+					<Modified>2007-06-12</Modified>
+				</Date>
+				<Description>
+					<p>NeTEx - Network Exchange. This subschema defines common SERVICE FEATURE  types.</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.netex.org.uk/schemas/1.0/xsd/netex_part_1/part1_ifopt}netex_ifopt_serviceFeature-v1.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom Software Ltd, 16 High Holborn, London WC1V 6BX</Publisher>
+				<Rights>Unclassified
+ <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the SIRI standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 1.0 Draft for approval</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport , Ports and maritime transport, Public transport,
+Rail transport, Roads and Road transport
+</Category>
+					<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>NeTEx Network Exchange - FEATURE types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SERVICE FEATURE identifier types for NeTEx.</xsd:documentation>
+	</xsd:annotation>
+	<!--===== ========================================================-->
+	<xsd:simpleType name="TypeOfServiceFeatureIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a TYPE OF SERVICE FEATURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TypeOfValueIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="TypeOfServiceFeatureRef" type="TypeOfServiceFeatureRefStructure" substitutionGroup="TypeOfEntityRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a TYPE OF SERVICE FEATURE.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="TypeOfServiceFeatureRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TYPE OF SERVICE FEATURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="TypeOfValueRefStructure">
+				<xsd:attribute name="ref" type="TypeOfServiceFeatureIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Reference to a TYPE OF Service FEATURE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="typeOfServiceFeatureRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of references to a TYPEs of SERVICE FEATURE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="TypeOfServiceFeatureRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/schema/1.03/xsd/netex_part_2/part2_frames/netex_serviceFrame_version-v1.0.xsd
+++ b/schema/1.03/xsd/netex_part_2/part2_frames/netex_serviceFrame_version-v1.0.xsd
@@ -1,1 +1,98 @@
-<?xml version="1.0" encoding="iso-8859-1"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_serviceFrame_version">	<xsd:include schemaLocation="../../netex_part_1/netex_all_objects_part1-v1.0.xsd"/>	<xsd:include schemaLocation="../../netex_framework/netex_frames/netex_commonFrame_version-v1.0.xsd"/>	<xsd:include schemaLocation="../netex_all_objects_part2-v1.0.xsd"/>	<!-- ======================================================================= -->	<xsd:simpleType name="ServiceFrameIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a SERVICE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="VersionFrameIdType"/>	</xsd:simpleType>	<xsd:element name="ServiceFrameRef" type="ServiceFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">		<xsd:annotation>			<xsd:documentation>Reference to a SERVICE FRAME.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ServiceFrameRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SERVICE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionFrameRefStructure">				<xsd:attribute name="ref" type="ServiceFrameIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of a SERVICE FRAME.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="ServiceFrame" abstract="false" substitutionGroup="CommonFrame">		<xsd:annotation>			<xsd:documentation>A coherent set of Service data to which the same frame VALIDITY CONDITIONs have been assigned.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="Service_VersionFrameStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="VersionFrameGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="ServiceFrameGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="ServiceFrameIdType"/>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>		<!-- 		<xsd:unique name="SfUniqueLineId">			<xsd:selector xpath=".//netex:lines/Line"/>			<xsd:field xpath="Id"/>		</xsd:unique> -->	</xsd:element>	<xsd:complexType name="Service_VersionFrameStructure" abstract="false">		<xsd:annotation>			<xsd:documentation>Type for a SERVICE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="Common_VersionFrameStructure">				<xsd:sequence>					<xsd:group ref="ServiceFrameGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="ServiceFrameGroup">		<xsd:annotation>			<xsd:documentation>Elements of a SERVICE FRAME.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element ref="Network" minOccurs="0"/>			<xsd:group ref="RouteInFrameGroup"/>			<xsd:group ref="FlexibleRouteInFrameGroup"/>			<xsd:group ref="CommonPointAndLInkFrameGroup"/>			<xsd:group ref="LineInFrameGroup"/>			<xsd:group ref="LineNetworkInFrameGroup"/>			<xsd:group ref="ServiceInFrameGroup"/>			<xsd:group ref="StopAssignmentInFrameGroup"/>			<xsd:group ref="TimingPatternInFrameGroup"/>			<xsd:group ref="JourneyPatternInFrameGroup"/>			<xsd:group ref="RoutingConstraintInFrameGroup"/>			<xsd:group ref="TimeDemandTypeInFrameGroup"/>			<xsd:group ref="NoticesInFrameGroup"/>			<xsd:group ref="PassengerInformationEquipmentInFrameGroup"/>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:netex="http://www.netex.org.uk/netex" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0" id="netex_serviceFrame_version">
+	<xsd:include schemaLocation="../../netex_part_1/netex_all_objects_part1-v1.0.xsd"/>
+	<xsd:include schemaLocation="../../netex_framework/netex_frames/netex_commonFrame_version-v1.0.xsd"/>
+	<xsd:include schemaLocation="../netex_all_objects_part2-v1.0.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="ServiceFrameIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a SERVICE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="VersionFrameIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="ServiceFrameRef" type="ServiceFrameRefStructure" abstract="false" substitutionGroup="VersionFrameRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SERVICE FRAME.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ServiceFrameRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SERVICE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionFrameRefStructure">
+				<xsd:attribute name="ref" type="ServiceFrameIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of a SERVICE FRAME.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="ServiceFrame" abstract="false" substitutionGroup="CommonFrame">
+		<xsd:annotation>
+			<xsd:documentation>A coherent set of Service data to which the same frame VALIDITY CONDITIONs have been assigned.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="Service_VersionFrameStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="VersionFrameGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="ServiceFrameGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="ServiceFrameIdType"/>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+		<!-- 
+		<xsd:unique name="SfUniqueLineId">
+			<xsd:selector xpath=".//netex:lines/Line"/>
+			<xsd:field xpath="Id"/>
+		</xsd:unique> -->
+	</xsd:element>
+	<xsd:complexType name="Service_VersionFrameStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a SERVICE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="Common_VersionFrameStructure">
+				<xsd:sequence>
+					<xsd:group ref="ServiceFrameGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ServiceFrameGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements of a SERVICE FRAME.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="Network" minOccurs="0"/>
+			<xsd:group ref="RouteInFrameGroup"/>
+			<xsd:group ref="FlexibleRouteInFrameGroup"/>
+			<xsd:group ref="CommonPointAndLInkFrameGroup"/>
+			<xsd:group ref="LineInFrameGroup"/>
+			<xsd:group ref="LineNetworkInFrameGroup"/>
+			<xsd:group ref="ServiceInFrameGroup"/>
+			<xsd:group ref="StopAssignmentInFrameGroup"/>
+			<xsd:group ref="TimingPatternInFrameGroup"/>
+			<xsd:group ref="JourneyPatternInFrameGroup"/>
+			<xsd:group ref="RoutingConstraintInFrameGroup"/>
+			<xsd:group ref="TimeDemandTypeInFrameGroup"/>
+			<xsd:group ref="NoticesInFrameGroup"/>
+			<xsd:group ref="PassengerInformationEquipmentInFrameGroup"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/netex_service/netex_dataObjectRequest_service-v1.0.xsd
+++ b/schema/1.03/xsd/netex_service/netex_dataObjectRequest_service-v1.0.xsd
@@ -40,7 +40,7 @@
 					<Requires>http://www.siri.org.uk/schemas/2.0/xsd/siri/siri_requests-v2.0.xsd</Requires> >
 				</Relation>
 				<Rights>Unclassified
- <Copyright>CEN, Crown Copyright 2009-2014</Copyright>
+ 					<Copyright>CEN, Crown Copyright 2009-2014</Copyright>
 				</Rights>
 				<Source>
 					<ul>
@@ -56,8 +56,7 @@
 					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
 Public transport, Bus services, Coach services, Bus stops and stations,
 Business and industry, Transport, 
-Roads and road transport
-</Category>
+Roads and road transport</Category>
 					<Project>CEN TC278 WG3 SG9.</Project>
 				</Subject>
 				<Title>NeTEx  XML schema.   Subschema describing the NeTEx SIRI data exchange services  </Title>
@@ -205,8 +204,7 @@ Roads and road transport
 				</xsd:sequence>
 				<xsd:attribute name="version" type="siri:VersionString" default="2.0">
 					<xsd:annotation>
-						<xsd:documentation>Version number of response. Fixed 
-</xsd:documentation>
+						<xsd:documentation>Version number of response. Fixed</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>

--- a/schema/1.03/xsd/siri/siri_request_errorConditions-v2.0.xsd
+++ b/schema/1.03/xsd/siri/siri_request_errorConditions-v2.0.xsd
@@ -1,1 +1,593 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2011 rel. 2 sp1 (x64) (http://www.altova.com) by Christophe Duquesne (Dryade) --><xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_request_errorConditions">	<xsd:include schemaLocation="../siri_utility/siri_types-v2.0.xsd"/>	<xsd:include schemaLocation="siri_request_support-v2.0.xsd"/>	<!-- ======================================================================= -->	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor>CEN TC278 WG3 SG7 Team</Contributor>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG7 Editor Nicholas Knowles, Kizoom. mailto:schemer@siri.org.uk</Creator>				<Date>					<Created>2012-03-24</Created>					 Factored out of SIRI request 				</Date>				<Date>					<Modified>2009-03-31</Modified>					 - Add errorConditionelement to enable WSDL axis binding 				</Date>				<Date>					<Modified>2011-04-18</Modified>					 - ErrorConditionStructure Line 841 should not be abstract. Fix from RV ixxi.biz						 Also Add ServiceConditionErrorConditionElement 						 						Add new error conditions												UnknownParticipant	Recipient for a message to be distributed is unknown. +SIRI v2.0						UnknownEndpoint	Endpoint to which a message is to be distributed is unknown. +SIRI v2.0						EndpointDeniedAccess	Distribution message could not be delivered because not authorised.. +SIRI v2.0						EndpointNotAvailable	Recipient of a message to be distributed is not available. +SIRI v2.0						UnapprovedKey	User authorisation Key is not  enabled. +SIRI v2.0												InvalidDataReferences	Request contains references to  identifiers that are not known.  +SIRI v2.0						ParametersIgnored	Request contained parameters that were not supported by the producer. A response has been provided but some parameters have been ignored. +SIRI v2.0						UnknownExtensions	Request contained extensions that were not supported bu the producer. A response has been provided but some or all extensions have been ignored.. +SIRI v2.0				</Date>				<Date>					<Modified>2012-03-23</Modified>					 +SIRI v2.0					  Add error number to Error structure					  Factor our Permission model to separate package siri_permissions				</Date>				<Description>					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common request error conditions </p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri/}siri_requests_errorConditions-v2.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>				<Relation>					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_uility/siri_types-v2.0.xsd</Requires>					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_uility/siri_participant-v2.0.xsd</Requires>				</Relation>				<Rights>Unclassified        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the VDV, RTIGXML and Trident standards.</li>					</ul>				</Source>				<Status>Version 2.0 Draft</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,Rail transport, Roads and road transport</Category>					<Project>CEN TC278 WG3 SG7</Project>				</Subject>				<Title>SIRI XML schema. Common Request Error Conditions </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SIRI Framework Error COnditions.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:element name="ErrorCondition" type="ErrorConditionStructure">		<xsd:annotation>			<xsd:documentation>Description of error or warning condition associated with response.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ErrorConditionStructure">		<xsd:annotation>			<xsd:documentation>Type for RequestErrorCondition.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:choice>				<xsd:group ref="ApplicationErrorGroup"/>			</xsd:choice>			<xsd:element name="Description" type="NaturalLanguageStringStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Text description of error.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:group name="SuccessInfoGroup">		<xsd:annotation>			<xsd:documentation>Additional information provided if request is successful.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="ValidUntil" type="xsd:dateTime" minOccurs="0">				<xsd:annotation>					<xsd:documentation>End of data horizon of the data producer.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="ShortestPossibleCycle" type="PositiveDurationType" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Minimum interval at which updates can be sent.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= -->	<xsd:element name="ErrorConditionElement" type="ErrorConditionElementStructure" abstract="false">		<xsd:annotation>			<xsd:documentation>Element fror an erroc condition  (for use in WSDL.)</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ErrorConditionElementStructure">		<xsd:annotation>			<xsd:documentation>Type for Standard ErrorConditions for Service request.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:choice>				<xsd:group ref="ServiceRequestErrorGroup"/>				<xsd:element ref="UnknownSubscriptionError"/>			</xsd:choice>			<xsd:element name="Description" type="ErrorDescriptionStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Text description of error.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:complexType name="ErrorDescriptionStructure">		<xsd:annotation>			<xsd:documentation>Type for Description of an error.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="xsd:string"/>		</xsd:simpleContent>	</xsd:complexType>	<!-- =======Error conditions========================================================== -->	<xsd:element name="ErrorCode" type="ErrorCodeStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a SIRI Error code.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ErrorCodeStructure">		<xsd:annotation>			<xsd:documentation>Type for Error Code.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="ErrorText" type="xsd:string" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Addtional Description of error. This allows a descripotion to be supplied when the Error code is used in a specific WSDL fault, rather than within a general error condition.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>		<xsd:attribute name="number" type="xsd:integer">			<xsd:annotation>				<xsd:documentation>Error code number associated with error.</xsd:documentation>			</xsd:annotation>		</xsd:attribute>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="ServiceDeliveryErrorConditionElement" type="ServiceDeliveryErrorConditionStructure" abstract="false">		<xsd:annotation>			<xsd:documentation>Element fror an erroc condition for use in WSDL.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ServiceDeliveryErrorConditionStructure">		<xsd:annotation>			<xsd:documentation>Type for Standard ErrorConditiosn for Service request.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:choice>				<xsd:group ref="ServiceRequestErrorGroup"/>			</xsd:choice>			<xsd:element name="Description" type="ErrorDescriptionStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Text description of error.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:group name="ServiceRequestErrorGroup">		<xsd:annotation>			<xsd:documentation>Errors that may arise in the execution of a request.</xsd:documentation>		</xsd:annotation>		<xsd:choice>			<xsd:group ref="DistributionErrorGroup"/>			<xsd:group ref="ApplicationErrorGroup"/>		</xsd:choice>	</xsd:group>	<!-- ===  DISTRIBUTION (+SIRI v2.0)================================================== -->	<xsd:group name="DistributionErrorGroup">		<xsd:annotation>			<xsd:documentation>Errors that may arise in the execution of a delegated distribution request. +SIRI v2.0</xsd:documentation>		</xsd:annotation>		<xsd:choice>			<xsd:element ref="UnapprovedKeyAccessError"/>			<xsd:element ref="UnknownParticipantError">				<xsd:annotation>					<xsd:documentation>Error: Recipient for a message to be distributed is unknown. I.e. delegatior is found, but  +SIRI v2.0</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element ref="UnknownEndpointError"/>			<xsd:element ref="EndpointDeniedAccessError"/>			<xsd:element ref="EndpointNotAvailableAccessError"/>		</xsd:choice>	</xsd:group>	<!-- ===Error: Unapproved Key Access ============================================= -->	<xsd:element name="UnapprovedKeyAccessError" type="UnapprovedKeyAccessStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Recipient of a message to be distributed is not available. +SIRI v2.0</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="UnapprovedKeyAccessStructure">		<xsd:annotation>			<xsd:documentation>Type for Error: UnapprovedKey +SIRI v2.0</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="Key" type="xsd:normalizedString" minOccurs="0">						<xsd:annotation>							<xsd:documentation>User key.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Capability Not Supported============================================== -->	<xsd:element name="UnknownParticipantError" type="UnknownParticipantErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Recipient for a message to be distributed is unknown. +SIRI v2.0</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="UnknownParticipantErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for Error: Unknown Participant. +SIRI v2.0</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="ParticipantRef" type="ParticipantRefStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Reference to  Participant who is unknown. + SIRI v2.0</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Unknown Endpoint ============================================ -->	<xsd:element name="UnknownEndpointError" type="UnknownEndpointErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Recipient for a message to be distributed is unknown. +SIRI v2.0</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="UnknownEndpointErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for Error: Unknown Endpoint +SIRI v2.0</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="Endpoint" type="EndpointAddress" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Endpoint that is not known. + SIRI v2.0</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Endpoint Denied Access ============================================= -->	<xsd:element name="EndpointDeniedAccessError" type="EndpointDeniedAccessStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error:Endpoint to which a message is to be distributed did not allow access by the cloient. +SIRI v2.0</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="EndpointDeniedAccessStructure">		<xsd:annotation>			<xsd:documentation>Type for Error: EndpointDeniedAccess +SIRI v2.0</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="Endpoint" type="EndpointAddress" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Endpoint that was denied access  + SIRI v2.0</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Endpoint Not Available============================================= -->	<xsd:element name="EndpointNotAvailableAccessError" type="EndpointNotAvailableAccessStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error:Recipient of a message to be distributed is not available. +SIRI v2.0</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="EndpointNotAvailableAccessStructure">		<xsd:annotation>			<xsd:documentation>Type for Error: EndpointNotAvailable +SIRI v2.0</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="Endpoint" type="EndpointAddress" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Endpoint that is noit available. + SIRI v2.0</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===APPLICATION================================================== -->	<!-- ===== ============================================ -->	<xsd:group name="ApplicationErrorGroup">		<xsd:annotation>			<xsd:documentation>Errors that may arise in the execution of a request.</xsd:documentation>		</xsd:annotation>		<xsd:choice>			<xsd:element ref="ServiceNotAvailableError"/>			<xsd:element ref="CapabilityNotSupportedError"/>			<xsd:element ref="AccessNotAllowedError"/>			<xsd:element ref="InvalidDataReferencesError"/>			<xsd:element ref="BeyondDataHorizon">				<xsd:annotation>					<xsd:documentation>Error: Data period or subscription period is outside of period covered by service.   +SIRI v2.0.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element ref="NoInfoForTopicError"/>			<xsd:element ref="ParametersIgnoredError"/>			<xsd:element ref="UnknownExtensionsError">				<xsd:annotation>					<xsd:documentation>Error: Request contained extensions that were not supported by the producer. A response has been provided but some or all extensions have been ignored.  +SIRI v2.0.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element ref="AllowedResourceUsageExceededError"/>			<xsd:element ref="OtherError"/>		</xsd:choice>	</xsd:group>	<!-- ===Error: Service Not Available ============================================= -->	<xsd:element name="ServiceNotAvailableError" type="ServiceNotAvailableErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Functional service is not available to use (but it is still capable of giving this response).</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ServiceNotAvailableErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for Service Not Available error.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="ExpectedRestartTime" type="xsd:dateTime" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Expected time for reavailability of service.  +SIRI v2.0</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Capability Not Supported============================================== -->	<xsd:element name="CapabilityNotSupportedError" type="CapabilityNotSupportedErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Service does not support the requested capability.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="CapabilityNotSupportedErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for Error: Service does not support requested capability.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="CapabilityRef" type="CapabilityCodeType" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Id of capabiliuty that is not supported.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Beyond Data Horizon ============================================== -->	<xsd:element name="BeyondDataHorizon" type="BeyondDataHorizonErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Data period or subscription period is outside of period covered by service.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="BeyondDataHorizonErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for error.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure"/>		</xsd:complexContent>	</xsd:complexType>	<!-- ===== AUTHORISATION========================================= -->	<!-- ===Error: Access not allowed ============================================= -->	<xsd:element name="AccessNotAllowedError" type="AccessNotAllowedErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Requestor is not authorised to the service or data requested.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AccessNotAllowedErrorStructure">		<xsd:annotation>			<xsd:documentation>Type forError:Access Not Allowed.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure"/>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: No Info for Topic================================================= -->	<xsd:element name="NoInfoForTopicError" type="NoInfoForTopicErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Valid request was made but service does not hold any data for the requested topic. expression.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="NoInfoForTopicErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for Error: No Info for Topic</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure"/>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Invalid Data References ======================================= -->	<xsd:element name="InvalidDataReferencesError" type="InvalidDataReferencesErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Request contains references to  identifiers that are not known.  +SIRI v2.0.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="InvalidDataReferencesErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for InvalidDataReferencesError:. +SIRI v2.0.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="InvalidRef" type="xsd:NMTOKEN" minOccurs="0" maxOccurs="unbounded">						<xsd:annotation>							<xsd:documentation>Invalid reference values encoountered.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Invalid Data References ======================================= -->	<xsd:element name="ParametersIgnoredError" type="ParametersIgnoredErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Request contained parameters that were not supported by the producer. A response has been provided but some parameters have been ignored. +SIRI v2.0.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ParametersIgnoredErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for Parameters Ignored Error:. +SIRI v2.0.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="ParameterName" type="xsd:string" minOccurs="0" maxOccurs="unbounded">						<xsd:annotation>							<xsd:documentation>Name of the unsupported parameter.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Unknown Extensions======================================= -->	<xsd:element name="UnknownExtensionsError" type="UnknownExtensionsErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Request contained extensions that were not supported by the producer. A response has been provided but some or all extensions have been ignored..  +SIRI v2.0.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="UnknownExtensionsErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for Unknown Extensions Error:. +SIRI v2.0.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="ExtensionName" type="xsd:string" minOccurs="0" maxOccurs="unbounded">						<xsd:annotation>							<xsd:documentation>Name of the unknown encountered extensions.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Allowed Resource Usage Exceeded ============================================= -->	<xsd:element name="AllowedResourceUsageExceededError" type="AllowedResourceUsageExceededErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Valid request was made but request would exceed the permitted resource usage of the client.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AllowedResourceUsageExceededErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for error. AllowedResourceUsageExceeded.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure"/>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<!-- ==== SUBSCRIPTION ERRORS=========================================== -->	<!-- ===Error: Unknown Subscriber  ============================================= -->	<xsd:element name="UnknownSubscriberError" type="UnknownSubscriberErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Subscriber not found.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="UnknownSubscriberErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for Error: Subscriber not found.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="SubscriberRef" type="ParticipantRefStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Id of subscriber that was not found + SIRI v2.0</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<!-- ===Error: Unknown Subscription  ============================================= -->	<xsd:element name="UnknownSubscriptionError" type="UnknownSubscriptionErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Subscription not found.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="UnknownSubscriptionErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for Error: Subscription not found.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure">				<xsd:sequence>					<xsd:element name="SubscriptionCode" type="SubscriptionQualifierStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Ubscription code that could not be found. + SIRI v2.0</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Error: Other Error ============================================= -->	<xsd:element name="OtherError" type="OtherErrorStructure" substitutionGroup="ErrorCode">		<xsd:annotation>			<xsd:documentation>Error: Error type other than the well defined codes.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="OtherErrorStructure">		<xsd:annotation>			<xsd:documentation>Type for error.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ErrorCodeStructure"/>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2011 rel. 2 sp1 (x64) (http://www.altova.com) by Christophe Duquesne (Dryade) -->
+<xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_request_errorConditions">
+	<xsd:include schemaLocation="../siri_utility/siri_types-v2.0.xsd"/>
+	<xsd:include schemaLocation="siri_request_support-v2.0.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>CEN TC278 WG3 SG7 Team</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG7 Editor Nicholas Knowles, Kizoom. mailto:schemer@siri.org.uk</Creator>
+				<Date>
+					<Created>2012-03-24</Created>
+					 Factored out of SIRI request 
+				</Date>
+				<Date>
+					<Modified>2009-03-31</Modified>
+					 - Add errorConditionelement to enable WSDL axis binding 
+				</Date>
+				<Date>
+					<Modified>2011-04-18</Modified>
+					 - ErrorConditionStructure Line 841 should not be abstract. Fix from RV ixxi.biz
+						 Also Add ServiceConditionErrorConditionElement 
+						 
+						Add new error conditions
+						
+						UnknownParticipant	Recipient for a message to be distributed is unknown. +SIRI v2.0
+						UnknownEndpoint	Endpoint to which a message is to be distributed is unknown. +SIRI v2.0
+						EndpointDeniedAccess	Distribution message could not be delivered because not authorised.. +SIRI v2.0
+						EndpointNotAvailable	Recipient of a message to be distributed is not available. +SIRI v2.0
+						UnapprovedKey	User authorisation Key is not  enabled. +SIRI v2.0
+						
+						InvalidDataReferences	Request contains references to  identifiers that are not known.  +SIRI v2.0
+						ParametersIgnored	Request contained parameters that were not supported by the producer. A response has been provided but some parameters have been ignored. +SIRI v2.0
+						UnknownExtensions	Request contained extensions that were not supported bu the producer. A response has been provided but some or all extensions have been ignored.. +SIRI v2.0
+
+				</Date>
+				<Date>
+					<Modified>2012-03-23</Modified>
+					 +SIRI v2.0
+					  Add error number to Error structure
+					  Factor our Permission model to separate package siri_permissions
+				</Date>
+				<Description>
+					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common request error conditions </p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri/}siri_requests_errorConditions-v2.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>
+				<Relation>
+					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_uility/siri_types-v2.0.xsd</Requires>
+					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_uility/siri_participant-v2.0.xsd</Requires>
+				</Relation>
+				<Rights>Unclassified
+
+        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the VDV, RTIGXML and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 2.0 Draft</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,
+Rail transport, Roads and road transport
+</Category>
+					<Project>CEN TC278 WG3 SG7</Project>
+				</Subject>
+				<Title>SIRI XML schema. Common Request Error Conditions </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SIRI Framework Error COnditions.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:element name="ErrorCondition" type="ErrorConditionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Description of error or warning condition associated with response.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ErrorConditionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for RequestErrorCondition.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:group ref="ApplicationErrorGroup"/>
+			</xsd:choice>
+			<xsd:element name="Description" type="NaturalLanguageStringStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Text description of error.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:group name="SuccessInfoGroup">
+		<xsd:annotation>
+			<xsd:documentation>Additional information provided if request is successful.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="ValidUntil" type="xsd:dateTime" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>End of data horizon of the data producer.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ShortestPossibleCycle" type="PositiveDurationType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Minimum interval at which updates can be sent.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="ErrorConditionElement" type="ErrorConditionElementStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Element fror an erroc condition  (for use in WSDL.)</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ErrorConditionElementStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Standard ErrorConditions for Service request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:group ref="ServiceRequestErrorGroup"/>
+				<xsd:element ref="UnknownSubscriptionError"/>
+			</xsd:choice>
+			<xsd:element name="Description" type="ErrorDescriptionStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Text description of error.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ErrorDescriptionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Description of an error.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- =======Error conditions========================================================== -->
+	<xsd:element name="ErrorCode" type="ErrorCodeStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a SIRI Error code.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ErrorCodeStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error Code.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="ErrorText" type="xsd:string" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Addtional Description of error. This allows a descripotion to be supplied when the Error code is used in a specific WSDL fault, rather than within a general error condition.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="number" type="xsd:integer">
+			<xsd:annotation>
+				<xsd:documentation>Error code number associated with error.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="ServiceDeliveryErrorConditionElement" type="ServiceDeliveryErrorConditionStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Element fror an erroc condition for use in WSDL.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ServiceDeliveryErrorConditionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Standard ErrorConditiosn for Service request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:group ref="ServiceRequestErrorGroup"/>
+			</xsd:choice>
+			<xsd:element name="Description" type="ErrorDescriptionStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Text description of error.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:group name="ServiceRequestErrorGroup">
+		<xsd:annotation>
+			<xsd:documentation>Errors that may arise in the execution of a request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:group ref="DistributionErrorGroup"/>
+			<xsd:group ref="ApplicationErrorGroup"/>
+		</xsd:choice>
+	</xsd:group>
+	<!-- ===  DISTRIBUTION (+SIRI v2.0)================================================== -->
+	<xsd:group name="DistributionErrorGroup">
+		<xsd:annotation>
+			<xsd:documentation>Errors that may arise in the execution of a delegated distribution request. +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element ref="UnapprovedKeyAccessError"/>
+			<xsd:element ref="UnknownParticipantError">
+				<xsd:annotation>
+					<xsd:documentation>Error: Recipient for a message to be distributed is unknown. I.e. delegatior is found, but  +SIRI v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="UnknownEndpointError"/>
+			<xsd:element ref="EndpointDeniedAccessError"/>
+			<xsd:element ref="EndpointNotAvailableAccessError"/>
+		</xsd:choice>
+	</xsd:group>
+	<!-- ===Error: Unapproved Key Access ============================================= -->
+	<xsd:element name="UnapprovedKeyAccessError" type="UnapprovedKeyAccessStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Recipient of a message to be distributed is not available. +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="UnapprovedKeyAccessStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error: UnapprovedKey +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="Key" type="xsd:normalizedString" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>User key.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Capability Not Supported============================================== -->
+	<xsd:element name="UnknownParticipantError" type="UnknownParticipantErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Recipient for a message to be distributed is unknown. +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="UnknownParticipantErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error: Unknown Participant. +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="ParticipantRef" type="ParticipantRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Reference to  Participant who is unknown. + SIRI v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Unknown Endpoint ============================================ -->
+	<xsd:element name="UnknownEndpointError" type="UnknownEndpointErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Recipient for a message to be distributed is unknown. +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="UnknownEndpointErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error: Unknown Endpoint +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="Endpoint" type="EndpointAddress" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Endpoint that is not known. + SIRI v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Endpoint Denied Access ============================================= -->
+	<xsd:element name="EndpointDeniedAccessError" type="EndpointDeniedAccessStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error:Endpoint to which a message is to be distributed did not allow access by the cloient. +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="EndpointDeniedAccessStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error: EndpointDeniedAccess +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="Endpoint" type="EndpointAddress" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Endpoint that was denied access  + SIRI v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Endpoint Not Available============================================= -->
+	<xsd:element name="EndpointNotAvailableAccessError" type="EndpointNotAvailableAccessStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error:Recipient of a message to be distributed is not available. +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="EndpointNotAvailableAccessStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error: EndpointNotAvailable +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="Endpoint" type="EndpointAddress" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Endpoint that is noit available. + SIRI v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===APPLICATION================================================== -->
+	<!-- ===== ============================================ -->
+	<xsd:group name="ApplicationErrorGroup">
+		<xsd:annotation>
+			<xsd:documentation>Errors that may arise in the execution of a request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element ref="ServiceNotAvailableError"/>
+			<xsd:element ref="CapabilityNotSupportedError"/>
+			<xsd:element ref="AccessNotAllowedError"/>
+			<xsd:element ref="InvalidDataReferencesError"/>
+			<xsd:element ref="BeyondDataHorizon">
+				<xsd:annotation>
+					<xsd:documentation>Error: Data period or subscription period is outside of period covered by service.   +SIRI v2.0.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="NoInfoForTopicError"/>
+			<xsd:element ref="ParametersIgnoredError"/>
+			<xsd:element ref="UnknownExtensionsError">
+				<xsd:annotation>
+					<xsd:documentation>Error: Request contained extensions that were not supported by the producer. A response has been provided but some or all extensions have been ignored.  +SIRI v2.0.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="AllowedResourceUsageExceededError"/>
+			<xsd:element ref="OtherError"/>
+		</xsd:choice>
+	</xsd:group>
+	<!-- ===Error: Service Not Available ============================================= -->
+	<xsd:element name="ServiceNotAvailableError" type="ServiceNotAvailableErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Functional service is not available to use (but it is still capable of giving this response).</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ServiceNotAvailableErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Service Not Available error.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="ExpectedRestartTime" type="xsd:dateTime" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Expected time for reavailability of service.  +SIRI v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Capability Not Supported============================================== -->
+	<xsd:element name="CapabilityNotSupportedError" type="CapabilityNotSupportedErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Service does not support the requested capability.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="CapabilityNotSupportedErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error: Service does not support requested capability.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="CapabilityRef" type="CapabilityCodeType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Id of capabiliuty that is not supported.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Beyond Data Horizon ============================================== -->
+	<xsd:element name="BeyondDataHorizon" type="BeyondDataHorizonErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Data period or subscription period is outside of period covered by service.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="BeyondDataHorizonErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for error.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===== AUTHORISATION========================================= -->
+	<!-- ===Error: Access not allowed ============================================= -->
+	<xsd:element name="AccessNotAllowedError" type="AccessNotAllowedErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Requestor is not authorised to the service or data requested.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AccessNotAllowedErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type forError:Access Not Allowed.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: No Info for Topic================================================= -->
+	<xsd:element name="NoInfoForTopicError" type="NoInfoForTopicErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Valid request was made but service does not hold any data for the requested topic. expression.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="NoInfoForTopicErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error: No Info for Topic</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Invalid Data References ======================================= -->
+	<xsd:element name="InvalidDataReferencesError" type="InvalidDataReferencesErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Request contains references to  identifiers that are not known.  +SIRI v2.0.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="InvalidDataReferencesErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for InvalidDataReferencesError:. +SIRI v2.0.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="InvalidRef" type="xsd:NMTOKEN" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Invalid reference values encoountered.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Invalid Data References ======================================= -->
+	<xsd:element name="ParametersIgnoredError" type="ParametersIgnoredErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Request contained parameters that were not supported by the producer. A response has been provided but some parameters have been ignored. +SIRI v2.0.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ParametersIgnoredErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Parameters Ignored Error:. +SIRI v2.0.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="ParameterName" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Name of the unsupported parameter.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Unknown Extensions======================================= -->
+	<xsd:element name="UnknownExtensionsError" type="UnknownExtensionsErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Request contained extensions that were not supported by the producer. A response has been provided but some or all extensions have been ignored..  +SIRI v2.0.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="UnknownExtensionsErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Unknown Extensions Error:. +SIRI v2.0.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="ExtensionName" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Name of the unknown encountered extensions.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Allowed Resource Usage Exceeded ============================================= -->
+	<xsd:element name="AllowedResourceUsageExceededError" type="AllowedResourceUsageExceededErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Valid request was made but request would exceed the permitted resource usage of the client.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AllowedResourceUsageExceededErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for error. AllowedResourceUsageExceeded.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<!-- ==== SUBSCRIPTION ERRORS=========================================== -->
+	<!-- ===Error: Unknown Subscriber  ============================================= -->
+	<xsd:element name="UnknownSubscriberError" type="UnknownSubscriberErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Subscriber not found.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="UnknownSubscriberErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error: Subscriber not found.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="SubscriberRef" type="ParticipantRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Id of subscriber that was not found + SIRI v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<!-- ===Error: Unknown Subscription  ============================================= -->
+	<xsd:element name="UnknownSubscriptionError" type="UnknownSubscriptionErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Subscription not found.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="UnknownSubscriptionErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Error: Subscription not found.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure">
+				<xsd:sequence>
+					<xsd:element name="SubscriptionCode" type="SubscriptionQualifierStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Ubscription code that could not be found. + SIRI v2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Error: Other Error ============================================= -->
+	<xsd:element name="OtherError" type="OtherErrorStructure" substitutionGroup="ErrorCode">
+		<xsd:annotation>
+			<xsd:documentation>Error: Error type other than the well defined codes.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="OtherErrorStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for error.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ErrorCodeStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/siri/siri_request_support-v2.0.xsd
+++ b/schema/1.03/xsd/siri/siri_request_support-v2.0.xsd
@@ -1,1 +1,190 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_requests">	<xsd:include schemaLocation="../siri_utility/siri_participant-v2.0.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor>CEN TC278 WG3 SG7 Team</Contributor>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG7 Editor Nicholas Knowles, Kizoom. mailto:schemer@siri.org.uk</Creator>				<Date>					<Created>2012-03-29</Created>				</Date>				<Date>					<Modified>2012-03-23</Modified>					 +SIRI v2.0					 					  Add error number to Error structure					  Factor our from siri_request packaged					  	  Relax typing on NotifcationRef to be normalized string				</Date>				<Description>					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common request processing identfiier types </p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri/}siri_request_support-v2.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>				<Relation>					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_types-v2.0.xsd</Requires>				</Relation>				<Rights>Unclassified        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the SIRI 1.0  standards.</li>					</ul>				</Source>				<Status>Version 2.0 Draft</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,Rail transport, Roads and road transport</Category>					<Project>CEN TC278 WG3 SG7</Project>				</Subject>				<Title>SIRI XML schema. Common Request identifier types </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SIRI Common Framework basic identifier types.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<!-- ======================================================================= -->	<xsd:complexType name="MessageQualifierStructure">		<xsd:annotation>			<xsd:documentation>Unique identifier of a message within SIRI functional service type and participant.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="xsd:normalizedString"/>		</xsd:simpleContent>	</xsd:complexType>	<xsd:complexType name="MessageRefStructure">		<xsd:annotation>			<xsd:documentation>Type for message ref.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="MessageQualifierStructure"/>		</xsd:simpleContent>	</xsd:complexType>	<xsd:complexType name="SubscriptionQualifierStructure">		<xsd:annotation>			<xsd:documentation>Type Unique identifier of Subscription within Participant.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="xsd:NMTOKEN"/>		</xsd:simpleContent>	</xsd:complexType>	<xsd:complexType name="SubscriptionFilterStructure">		<xsd:annotation>			<xsd:documentation>Type Unique identifier of Subscription Filter within Participant.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="xsd:NMTOKEN"/>		</xsd:simpleContent>	</xsd:complexType>	<xsd:complexType name="SubscriptionFilterRefStructure">		<xsd:annotation>			<xsd:documentation>Type Unique identifier of Subscription Filter within Participant.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="xsd:NMTOKEN"/>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="RequestTimestamp" type="xsd:dateTime">		<xsd:annotation>			<xsd:documentation>Timestamp on request.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:element name="RequestorRef" type="ParticipantRefStructure">		<xsd:annotation>			<xsd:documentation>Reference to a requestor - Participant Code.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:simpleType name="EndpointAddress">		<xsd:annotation>			<xsd:documentation>Type for a endpoint.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:anyURI"/>	</xsd:simpleType>	<xsd:element name="ResponseTimestamp" type="xsd:dateTime">		<xsd:annotation>			<xsd:documentation>Time individual response element was created.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<!-- ============WSDL========================================================= -->	<xsd:simpleType name="ItemIdentifierType">		<xsd:annotation>			<xsd:documentation>Type for identifier of an Item. A transient reference for efficient handling of events.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN"/>	</xsd:simpleType>	<xsd:complexType name="ItemRefStructure">		<xsd:annotation>			<xsd:documentation>Type for reference to an Item.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="ItemIdentifierType"/>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="IncludeTranslations" type="xsd:boolean">		<xsd:annotation>			<xsd:documentation>Whether additional translations of text names are to be included in elements. If false, then only one element should be returned.  Default is false.Where multiple values are returned The first element returned ill be used as the default value.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<!-- ======================================================================= -->	<xsd:complexType name="CapabilityRefStructure">		<xsd:annotation>			<xsd:documentation>Type for capability ref.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="CapabilityCodeType"/>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="CapabilityCodeType">		<xsd:annotation>			<xsd:documentation>Type for capability code.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN"/>	</xsd:simpleType>	<!-- ==== Enums =================================== -->	<xsd:simpleType name="CommunicationsTransportMethodEnumeration">		<xsd:annotation>			<xsd:documentation>Enumeration of communications transport method usage.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN">			<xsd:enumeration value="httpPost"/>			<xsd:enumeration value="other"/>			<xsd:enumeration value="wsdlSoap"/>			<xsd:enumeration value="wsdlSoapDocumentLiteral"/>			<xsd:enumeration value="httpUrlJSON"/>			<xsd:enumeration value="httpUrlProtoBuffers"/>		</xsd:restriction>	</xsd:simpleType>	<xsd:simpleType name="CompressionMethodEnumeration">		<xsd:annotation>			<xsd:documentation>Enumeration of compression usage.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN">			<xsd:enumeration value="gzip"/>			<xsd:enumeration value="none"/>			<xsd:enumeration value="other"/>		</xsd:restriction>	</xsd:simpleType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_requests">
+	<xsd:include schemaLocation="../siri_utility/siri_participant-v2.0.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>CEN TC278 WG3 SG7 Team</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG7 Editor Nicholas Knowles, Kizoom. mailto:schemer@siri.org.uk</Creator>
+				<Date>
+					<Created>2012-03-29</Created>
+				</Date>
+				<Date>
+					<Modified>2012-03-23</Modified>
+					 +SIRI v2.0
+					 
+					  Add error number to Error structure
+					  Factor our from siri_request packaged
+					  	  Relax typing on NotifcationRef to be normalized string
+				</Date>
+				<Description>
+					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common request processing identfiier types </p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri/}siri_request_support-v2.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>
+				<Relation>
+					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_types-v2.0.xsd</Requires>
+				</Relation>
+				<Rights>Unclassified
+
+        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the SIRI 1.0  standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 2.0 Draft</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,
+Rail transport, Roads and road transport
+</Category>
+					<Project>CEN TC278 WG3 SG7</Project>
+				</Subject>
+				<Title>SIRI XML schema. Common Request identifier types </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SIRI Common Framework basic identifier types.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<!-- ======================================================================= -->
+	<xsd:complexType name="MessageQualifierStructure">
+		<xsd:annotation>
+			<xsd:documentation>Unique identifier of a message within SIRI functional service type and participant.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:normalizedString"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="MessageRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for message ref.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="MessageQualifierStructure"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="SubscriptionQualifierStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type Unique identifier of Subscription within Participant.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:NMTOKEN"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="SubscriptionFilterStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type Unique identifier of Subscription Filter within Participant.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:NMTOKEN"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="SubscriptionFilterRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type Unique identifier of Subscription Filter within Participant.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:NMTOKEN"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="RequestTimestamp" type="xsd:dateTime">
+		<xsd:annotation>
+			<xsd:documentation>Timestamp on request.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="RequestorRef" type="ParticipantRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a requestor - Participant Code.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:simpleType name="EndpointAddress">
+		<xsd:annotation>
+			<xsd:documentation>Type for a endpoint.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:anyURI"/>
+	</xsd:simpleType>
+	<xsd:element name="ResponseTimestamp" type="xsd:dateTime">
+		<xsd:annotation>
+			<xsd:documentation>Time individual response element was created.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!-- ============WSDL========================================================= -->
+	<xsd:simpleType name="ItemIdentifierType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of an Item. A transient reference for efficient handling of events.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN"/>
+	</xsd:simpleType>
+	<xsd:complexType name="ItemRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for reference to an Item.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="ItemIdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="IncludeTranslations" type="xsd:boolean">
+		<xsd:annotation>
+			<xsd:documentation>Whether additional translations of text names are to be included in elements. If false, then only one element should be returned.  Default is false.
+
+Where multiple values are returned The first element returned ill be used as the default value.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="CapabilityRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for capability ref.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="CapabilityCodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="CapabilityCodeType">
+		<xsd:annotation>
+			<xsd:documentation>Type for capability code.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN"/>
+	</xsd:simpleType>
+	<!-- ==== Enums =================================== -->
+	<xsd:simpleType name="CommunicationsTransportMethodEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Enumeration of communications transport method usage.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="httpPost"/>
+			<xsd:enumeration value="other"/>
+			<xsd:enumeration value="wsdlSoap"/>
+			<xsd:enumeration value="wsdlSoapDocumentLiteral"/>
+			<xsd:enumeration value="httpUrlJSON"/>
+			<xsd:enumeration value="httpUrlProtoBuffers"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="CompressionMethodEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Enumeration of compression usage.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="gzip"/>
+			<xsd:enumeration value="none"/>
+			<xsd:enumeration value="other"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+</xsd:schema>

--- a/schema/1.03/xsd/siri/siri_requests-v2.0.xsd
+++ b/schema/1.03/xsd/siri/siri_requests-v2.0.xsd
@@ -277,7 +277,7 @@ Rail transport, Roads and road transport
 			<xsd:documentation>Subsititutable type for a SIRI Functional Service request.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="AbstractFunctionalServiceRequestStructure">
+	<xsd:complexType name="AbstractFunctionalServiceRequestStructure" abstract="true">
 		<xsd:annotation>
 			<xsd:documentation>Abstract Service Request for SIRI Service request.</xsd:documentation>
 		</xsd:annotation>

--- a/schema/1.03/xsd/siri/siri_requests-v2.0.xsd
+++ b/schema/1.03/xsd/siri/siri_requests-v2.0.xsd
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_requests">
+	<!-- ===Dependencies ======================================= -->
+	<!-- ======================================================================= -->
+	<xsd:include schemaLocation="../siri_utility/siri_utility-v1.1.xsd"/>
+	<xsd:include schemaLocation="../siri_utility/siri_location-v2.0.xsd"/>
+	<xsd:include schemaLocation="siri_request_errorConditions-v2.0.xsd"/>
+	<!-- ======================================================================= -->
 	<xsd:annotation>
 		<xsd:appinfo>
 			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
@@ -125,11 +131,7 @@ Rail transport, Roads and road transport
 		</xsd:appinfo>
 		<xsd:documentation>SIRI Common Request Framework.</xsd:documentation>
 	</xsd:annotation>
-	<!-- ======================================================================= -->
-	<xsd:include schemaLocation="../siri_utility/siri_utility-v1.1.xsd"/>
-	<xsd:include schemaLocation="../siri_utility/siri_location-v2.0.xsd"/>
-	<xsd:include schemaLocation="siri_request_errorConditions-v2.0.xsd"/>
-	<!-- ======================================================================= -->
+
 	<!-- ======================================================================= -->
 	<xsd:element name="AbstractRequest" type="AbstractRequestStructure" abstract="true">
 		<xsd:annotation>
@@ -275,7 +277,7 @@ Rail transport, Roads and road transport
 			<xsd:documentation>Subsititutable type for a SIRI Functional Service request.</xsd:documentation>
 		</xsd:annotation>
 	</xsd:element>
-	<xsd:complexType name="AbstractFunctionalServiceRequestStructure" abstract="true">
+	<xsd:complexType name="AbstractFunctionalServiceRequestStructure">
 		<xsd:annotation>
 			<xsd:documentation>Abstract Service Request for SIRI Service request.</xsd:documentation>
 		</xsd:annotation>

--- a/schema/1.03/xsd/siri/siri_requests-v2.0.xsd
+++ b/schema/1.03/xsd/siri/siri_requests-v2.0.xsd
@@ -1,1 +1,1081 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_requests">	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor>CEN TC278 WG3 SG7 Team</Contributor>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG7 Editor Nicholas Knowles, Kizoom. mailto:schemer@siri.org.uk</Creator>				<Date>					<Created>2004-09-29</Created>				</Date>				<Date>					<Modified>2004-10-01</Modified>				</Date>				<Date>					<Modified>2005-02-14</Modified>				</Date>				<Date>					<Modified>2005-02-20</Modified>				</Date>				<Date>					<Modified>2005-05-11</Modified>				</Date>				<Date>					<Modified>2005-11-20</Modified>				</Date>				<Date>					<Modified>2007-03-29</Modified>				</Date>				<Date>					<Modified>2008-11-11</Modified>					 -- add substitution groups for      AbstractRequest     AbstractResponse     AbstractFunctionalServiceRequest     AbstractFunctionalServiceSubscriptionRequest     AbstractFunctionalServiceDelivery     AbstractFunctionalServiceCapabilityRequest     AbstractFunctionalServiceCapabilityDelivery     AbstractDiscoveryDelivery     ErrorCode     				</Date>				<Date>					<Modified>2008-11-13</Modified>					 Move abstract discovery deliveries to here from siri_discoveries 				</Date>				<Date>					<Modified>2008-11-17</Modified>					 -- Add abstract discovery request        Make request and response descendent of Request and Response Types 				</Date>				<Date>					<Modified>2009-03-31</Modified>					 - Add ErrorConditionelement to enable WSDL axis binding 				</Date>				<Date>					<Modified>2011-04-18</Modified>					 - ErrorConditionStructure Line 841 should not be abstract. Fix from RV ixxi.biz						 Also Add ServiceConditionErrorConditionElement 				</Date>				<Date>					<Modified>2012-03-23</Modified>					 +SIRI v2.0					  Add error number to Error structure					  factor out base identifier defintiiosn so can be share dwith error codes					  Factor out error codes					  Factor our Permission model to separate package siri_permissions				</Date>				<Date>					<Modified>2012-06-17</Modified>					 +SIRI v2.0 x					  Add delegator endpoint group to ServceRequest and FunctionalServcieResponse				</Date>				<Date>					<Modified>2013-02-11</Modified>					Added AbstractRequiredIdentifiedItemStructure					Added AbstractRequiredReferencingItemStructure				</Date>				<Date>					<Modified>2014-07-12</Modified>					Structure					Added AbstractRequiredReferencingItemStructure				</Date>				<Description>					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common request processing elements</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri/}siri_requests-v2.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>				<Relation>					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_types-v2.0.xsd</Requires>				</Relation>				<Rights>Unclassified        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the VDV, RTIGXML and Trident standards.</li>					</ul>				</Source>				<Status>Version 2.0 Draft</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,Rail transport, Roads and road transport</Category>					<Project>CEN TC278 WG3 SG7</Project>				</Subject>				<Title>SIRI XML schema. Common Request elements. </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SIRI Common Request Framework.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:include schemaLocation="../siri_utility/siri_utility-v1.1.xsd"/>	<xsd:include schemaLocation="../siri_utility/siri_location-v2.0.xsd"/>	<xsd:include schemaLocation="siri_request_errorConditions-v2.0.xsd"/>	<!-- ======================================================================= -->	<!-- ======================================================================= -->	<xsd:element name="AbstractRequest" type="AbstractRequestStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a timestamped SIRI request.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AbstractRequestStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for General SIRI Request.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element ref="RequestTimestamp"/>		</xsd:sequence>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="AuthenticatedRequest" type="AuthenticatedRequestStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Subsititutable type for an authenticated request Authenticated.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AuthenticatedRequestStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for Authticated SIRI Request.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AbstractRequestStructure">				<xsd:group ref="AuthenticatedRequestGroup"/>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="AuthenticatedRequestGroup">		<xsd:annotation>			<xsd:documentation>Elemenst for authecticiation. +SIRI v2.0</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="AccountId" type="xsd:NMTOKEN" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Account Identifier. May be used to attribute requests to a particular application provider and authentication key. The account  may be common to all users of an application, or to an individual user. Note that to identify an individual user the  RequestorRef can be used with an anonymised token.  .     +SIRI v2.0</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="AccountKey" type="xsd:normalizedString" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Authentication key for request. May be used to authenticate requests from a particular account. +SIRI v2.0</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= -->	<xsd:complexType name="RequestStructure">		<xsd:annotation>			<xsd:documentation>Type for General SIRI Request.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AuthenticatedRequestStructure">				<xsd:sequence>					<xsd:group ref="RequestorEndpointGroup"/>					<xsd:group ref="DelegatorEndpointGroup">						<xsd:annotation>							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>						</xsd:annotation>					</xsd:group>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="RequestorEndpointGroup">		<xsd:annotation>			<xsd:documentation>Elements relating to system that sent request.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Address to which response is to be sent. This may also be determined from RequestorRef and preconfigured data.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element ref="RequestorRef"/>			<xsd:element name="MessageIdentifier" type="MessageQualifierStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Arbitrary unique identifier that can be used to reference this message in subsequent interactions.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:group name="DelegatorEndpointGroup">		<xsd:annotation>			<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking informattion relating to the original requestor. This allows the aggregation to be stateless.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="DelegatorAddress" type="EndpointAddress" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Address of original Consumer, i.e. requesting system to which delegating response is to be  returned. +SIRI 2.0</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="DelegatorRef" type="ParticipantRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Identifier of delegating system that originated message. +SIRI 2.0</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= -->	<xsd:element name="AbstractTrackedRequest" type="RequestStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a SIRI request with requestor dteials tracked.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<!-- ======================================================================= -->	<xsd:element name="AbstractServiceRequest" type="AbstractServiceRequestStructure" abstract="true" substitutionGroup="AbstractRequest">		<xsd:annotation>			<xsd:documentation>Substitutable type for a SIRI Functional Service request.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AbstractServiceRequestStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Abstract Service Request for SIRI Service request.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AbstractRequestStructure">				<xsd:sequence>					<xsd:group ref="ContextualisedRequestEndpointGroup">						<xsd:annotation>							<xsd:documentation>Unique reference to request: participant and SIRI service type are given by context. Used on requests that are embedded in the context of another request. Only a message identfiier may be needed.</xsd:documentation>						</xsd:annotation>					</xsd:group>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="ContextualisedRequestEndpointGroup">		<xsd:annotation>			<xsd:documentation>Unique reference to request: participant and SIRI service type are given by context. Used on requests that are embedded in the context of another request.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="MessageIdentifier" type="MessageQualifierStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Arbitrary unique reference to this message.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:element name="AbstractFunctionalServiceRequest" type="AbstractFunctionalServiceRequestStructure" abstract="true" substitutionGroup="AbstractServiceRequest">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a SIRI Functional Service request.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AbstractFunctionalServiceRequestStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Abstract Service Request for SIRI Service request.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AbstractServiceRequestStructure"/>		</xsd:complexContent>	</xsd:complexType>	<!-- ===Request Context================================================================== -->	<xsd:complexType name="AbstractSubscriptionStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for SIRI Service subscriptions.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:group ref="SubscriptionIdentityGroup"/>			<xsd:element name="InitialTerminationTime" type="xsd:dateTime">				<xsd:annotation>					<xsd:documentation>Requested end time for subscription.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:element name="AbstractFunctionalServiceSubscriptionRequest" type="AbstractSubscriptionStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a SIRI Functional Service subscription request.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:group name="SubscriptionIdentityGroup">		<xsd:annotation>			<xsd:documentation>Type for unique identifier of a subscription.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="SubscriberRef" type="ParticipantRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Participant identifier of Subscriber. Normally this will be given by context, i.e. be the same as on the Subscription Request.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="SubscriptionIdentifier" type="SubscriptionQualifierStructure">				<xsd:annotation>					<xsd:documentation>Identifier to be given to Subscription.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:complexType name="SubscriptionContextStructure">		<xsd:annotation>			<xsd:documentation>Type for Subscription context - Configuration parameters which may be evrriden.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="HeartbeatInterval" type="PositiveDurationType" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Interval for heartbeat.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:complexType name="AbstractSubscriptionRequestStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for COmmon Subscription Request.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="RequestStructure">				<xsd:sequence>					<xsd:group ref="SubscriberEndpointGroup"/>					<xsd:element name="SubscriptionContext" type="SubscriptionContextStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>General values that apply to subscription. Usually set by configuration.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="AbstractResponse" type="ResponseStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a SIRI response.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ResponseStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>General Type for General SIRI Response.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element ref="ResponseTimestamp"/>		</xsd:sequence>	</xsd:complexType>	<xsd:group name="ServiceDeliveryRequestStatusGroup">		<xsd:annotation>			<xsd:documentation>Status Information for overall request. Specific error conditions will be given on each individual request.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Status" type="xsd:boolean" default="true" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Whether the complerte request could be processed successfully or not. Default is 'true'. If any of the individual requests within the delivery failed, should be set to ' false'.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="ErrorCondition" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Description of any error or warning conditions that appluy to the overall request. More Specific error conditions should be included on each request that fails.</xsd:documentation>				</xsd:annotation>				<xsd:complexType>					<xsd:sequence>						<xsd:choice>							<xsd:element ref="CapabilityNotSupportedError"/>							<xsd:element ref="OtherError"/>						</xsd:choice>						<xsd:element name="Description" type="ErrorDescriptionStructure" minOccurs="0">							<xsd:annotation>								<xsd:documentation>Text description of error.</xsd:documentation>							</xsd:annotation>						</xsd:element>					</xsd:sequence>				</xsd:complexType>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:element name="ProducerResponse" type="ProducerResponseStructure" abstract="true" substitutionGroup="AbstractResponse">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a SIRI r Producer esponse.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ProducerResponseStructure">		<xsd:annotation>			<xsd:documentation>Type for General SIRI Producer Response.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ResponseStructure">				<xsd:sequence>					<xsd:group ref="ProducerResponseEndpointGroup"/>					<xsd:group ref="DelegatorEndpointGroup">						<xsd:annotation>							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>						</xsd:annotation>					</xsd:group>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="DeliveryStatusGroup">		<xsd:annotation>			<xsd:documentation>Status Information for individual request.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element ref="Status" minOccurs="0"/>			<xsd:element name="ErrorCondition" type="ServiceDeliveryErrorConditionStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Description of any error or warning condition.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:group ref="SuccessInfoGroup"/>		</xsd:sequence>	</xsd:group>	<xsd:complexType name="AbstractNotificationStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for Notification Request.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ProducerRequestEndpointStructure"/>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:element name="AbstractFunctionalServiceDelivery" type="AbstractServiceDeliveryStructure" abstract="true" substitutionGroup="AbstractResponse">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a SIRI Functional Service Deivery.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AbstractServiceDeliveryStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for Common elementd for a SIRI service delivery of the Form xxxDelivery.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ResponseStructure">				<xsd:sequence>					<xsd:choice>						<xsd:group ref="ContextualisedResponseEndpointGroup"/>						<xsd:group ref="SubscriptionIdentifierResourcePropertyGroup"/>					</xsd:choice>					<xsd:group ref="DelegatorEndpointGroup">						<xsd:annotation>							<xsd:documentation>If request has been proxied by an intermediate  aggregting system, trackng informattion relating to the original requestor. This allows the aggregation to be stateless.</xsd:documentation>						</xsd:annotation>					</xsd:group>					<xsd:group ref="DeliveryStatusGroup"/>					<xsd:group ref="DeliveryDefaultGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="DeliveryDefaultGroup">		<xsd:annotation>			<xsd:documentation>Common defaults.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="DefaultLanguage" type="xsd:language" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Default language for text elements.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:group name="SubscriberEndpointGroup">		<xsd:annotation>			<xsd:documentation>Unique reference to request. May be used to reference request in subsequent interactions.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="ConsumerAddress" type="EndpointAddress" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Address to which data is to be sent, if different from Address. This may also be determined from RequestorRef and preconfigured data.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="SubscriptionFilterIdentifier" type="xsd:NMTOKEN" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Reference to a Subscription Filter with which this subscription is to be aggregated for purposes of notification and delivery. If absent, use the default filter. If present, use any existing filter with that identifier, if none found, create a new one. Optional SIRI feature.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:group name="SubscriptionIdentifierResourcePropertyGroup">		<xsd:annotation>			<xsd:documentation>Unique reference to subscription May be used to reference subscription in subsequent interactions.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="SubscriberRef" type="ParticipantRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Unique identifier of Subscriber - reference to a Participant.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="SubscriptionFilterRef" type="SubscriptionFilterRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Unique identifier of Subscription filter to which this subscription is assigned. If there is onlya single filter, then can be omitted.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="SubscriptionRef" type="SubscriptionQualifierStructure">				<xsd:annotation>					<xsd:documentation>Reference to a service subscription: unique within Service and Subscriber.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:group name="OptionalSubscriberEndpointGroup">		<xsd:annotation>			<xsd:documentation>Unique reference to subscription May be used to reference subscription in subsequent interactions.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="SubscriberRef" type="ParticipantRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>If Delivery is for a Subscription, Participant reference of Subscriber.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="SubscriptionRef" type="SubscriptionQualifierStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>If Delivery is for a Subscription, unique identifier of service subscription request within Service and subscriber - a Timestamp.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:group name="ContextualisedResponseEndpointGroup">		<xsd:annotation>			<xsd:documentation>Endpoint reference proprerties for response message: participant and SIRI service type are given by context.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="RequestMessageRef" type="MessageQualifierStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Arbitrary unique reference to the request which gave rise to this message.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:element name="Status" type="xsd:boolean" default="true">		<xsd:annotation>			<xsd:documentation>Whether the request was processed successfully or not. Default is 'true'.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<!-- ============WSDL========================================================= -->	<xsd:complexType name="ConsumerRequestEndpointStructure">		<xsd:annotation>			<xsd:documentation>Type for Unique reference to this request, created by Consumer. May be used to reference the request in subsequent interactions. Used by WSDL.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AuthenticatedRequestStructure">				<xsd:sequence>					<xsd:group ref="ConsumerRequestEndpointGroup"/>					<xsd:group ref="DelegatorEndpointGroup">						<xsd:annotation>							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>						</xsd:annotation>					</xsd:group>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="ConsumerRequestEndpointGroup">		<xsd:annotation>			<xsd:documentation>Unique reference to this request, created by Consumer. May be used to reference the request in subsequent interactions.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Address to which response is to be sent. This may also be determined from RequestorRef and preconfigured data.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="ConsumerRef" type="ParticipantRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Unique identifier of Consumer - a Participant reference.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="MessageIdentifier" type="MessageQualifierStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Arbitrary unique reference to this message. Some systems may use just timestamp for this.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:group name="ConsumerResponseEndpointGroup">		<xsd:annotation>			<xsd:documentation>Unique reference to this response message from Consumer. May be used to reference the response in subsequent interactions.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="ConsumerRef" type="ParticipantRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Unique identifier of Consumer - a Participant reference.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="RequestMessageRef" type="MessageRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Reference to an arbitrary unique idenitifer associated with the request which gave rise to this response.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:complexType name="ConsumerResponseEndpointStructure">		<xsd:annotation>			<xsd:documentation>Type for Unique reference to this response created by Consumer. May be used to reference the request in subsequent interactions. Used by WSDL.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ResponseStructure">				<xsd:sequence>					<xsd:group ref="ConsumerResponseEndpointGroup"/>					<xsd:group ref="DelegatorEndpointGroup">						<xsd:annotation>							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>						</xsd:annotation>					</xsd:group>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ============WSDL========================================================= -->	<xsd:element name="ProducerRequest" type="ProducerRequestEndpointStructure" abstract="true" substitutionGroup="AuthenticatedRequest"/>	<xsd:complexType name="ProducerRequestEndpointStructure">		<xsd:annotation>			<xsd:documentation>Type for Unique reference to request to the producer. May be used to reference request in subsequent interactions. Used for WSDL.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AuthenticatedRequestStructure">				<xsd:sequence>					<xsd:group ref="ProducerRequestEndpointGroup"/>					<xsd:group ref="DelegatorEndpointGroup">						<xsd:annotation>							<xsd:documentation>If request has been proxied by an intermediate  aggregting system, trackng informattion relating to the original requestor. This allows the aggregation to be stateless.</xsd:documentation>						</xsd:annotation>					</xsd:group>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="ProducerRequestEndpointGroup">		<xsd:annotation>			<xsd:documentation>Unique reference to request from producer. May be used to reference request in subsequent interactions.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Address to which response is to be sent. This may also be determined from ProducerRef and preconfigured data.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="ProducerRef" type="ParticipantRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Unique identifier of Producer - Participant reference.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="MessageIdentifier" type="MessageQualifierStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Arbitrary unique reference to this message. Some systems may use just timestamp for this. Where there are multiple SubscriptionFilters, this can be used to distinguish between different notifications for different filters.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:group name="ResponseEndpointGroup">		<xsd:annotation>			<xsd:documentation>Unique reference to response May be used to reference response in subsequent interactions.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Address for further interaction.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="ResponderRef" type="ParticipantRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Participant reference that identifies responder.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="RequestMessageRef" type="MessageQualifierStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Reference to an arbitrary unique reference associated with the request which gave rise to this response.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:complexType name="ResponseEndpointStructure">		<xsd:annotation>			<xsd:documentation>Type for Unique reference to reponse. May be used to reference request in subsequent interactions. Used for WSDL  .</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ResponseStructure">				<xsd:sequence>					<xsd:group ref="ResponseEndpointGroup"/>					<xsd:group ref="DelegatorEndpointGroup">						<xsd:annotation>							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>						</xsd:annotation>					</xsd:group>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="ProducerResponseEndpointGroup">		<xsd:annotation>			<xsd:documentation>Unique reference to reponse from producer. May be used to reference request in subsequent interactions.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="ProducerRef" type="ParticipantRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Unique identifier of Producer - Participant reference.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Endpoint Address to which acknowledgements to confirm delivery are to be sent.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="ResponseMessageIdentifier" type="MessageQualifierStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>An arbitrary unique reference associated with the response which may be used to reference it.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="RequestMessageRef" type="MessageRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Reference to an arbitrary unique identifier associated with the request which gave rise to this response.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:complexType name="ProducerResponseEndpointStructure">		<xsd:annotation>			<xsd:documentation>Type for Unique reference to reponse from producer. May be used to reference request in subsequent interactions. Used for WSDL.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ResponseStructure">				<xsd:sequence>					<xsd:group ref="ProducerResponseEndpointGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ============Recorded Items========================================================== -->	<xsd:complexType name="AbstractItemStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for an Activity.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="RecordedAtTime" type="xsd:dateTime">				<xsd:annotation>					<xsd:documentation>Time at which data was recorded.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:complexType name="AbstractIdentifiedItemStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for an Activity that can be referenced.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AbstractItemStructure">				<xsd:sequence>					<xsd:element name="ItemIdentifier" type="ItemIdentifierType" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Identifier of item.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:complexType name="AbstractRequiredIdentifiedItemStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for an Activity that can be referenced.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AbstractItemStructure">				<xsd:sequence>					<xsd:element name="ItemIdentifier" type="ItemIdentifierType">						<xsd:annotation>							<xsd:documentation>Identifier of item.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:complexType name="AbstractReferencingItemStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for an Activity that references a previous Activity.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AbstractItemStructure">				<xsd:sequence>					<xsd:element name="ItemRef" type="ItemRefStructure" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Reference to an Activity Element of  a delivery.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:complexType name="AbstractRequiredReferencingItemStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for an Activity that references a previous Activity.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AbstractItemStructure">				<xsd:sequence>					<xsd:element name="ItemRef" type="ItemRefStructure">						<xsd:annotation>							<xsd:documentation>Reference to an Activity Element of  a delivery.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<!-- ======================================================================= -->	<!-- ======================================================================= -->	<xsd:element name="AbstractFunctionalServiceCapabilitiesRequest" type="AbstractServiceRequestStructure" abstract="true" substitutionGroup="AbstractServiceRequest">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a SIRI Functional Service Capabiloities equest.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ServiceCapabilitiesRequestStructure">		<xsd:annotation>			<xsd:documentation>Type for ServcieCapabilities request.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AbstractServiceRequestStructure">				<xsd:sequence>					<xsd:element name="ParticipantPermissions" type="xsd:boolean" default="false" minOccurs="0">						<xsd:annotation>							<xsd:documentation>Whether to include the requestors permissions in the response. Only applies if Access control capability supported. Default is 'false'.</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element ref="Extensions" minOccurs="0"/>				</xsd:sequence>				<xsd:attribute name="version" type="VersionString" default="2.0">					<xsd:annotation>						<xsd:documentation>Version number of request. Fixed.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="CapabilityStatusGroup">		<xsd:annotation>			<xsd:documentation>Status Information for individual request.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element ref="Status" minOccurs="0"/>			<xsd:element name="ErrorCondition" type="ServiceDeliveryErrorConditionStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Description of any error or warning condition.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= -->	<xsd:element name="AbstractFunctionalServiceCapabilitiesResponse" type="AbstractServiceCapabilitiesResponseStructure" abstract="true" substitutionGroup="AbstractResponse">		<xsd:annotation>			<xsd:documentation>Subsititutable type for a SIRI Functional Service Capabilities Response.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AbstractServiceCapabilitiesResponseStructure">		<xsd:annotation>			<xsd:documentation>Type for capabilities response.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ResponseStructure">				<xsd:sequence>					<xsd:group ref="ContextualisedResponseEndpointGroup"/>					<xsd:group ref="DelegatorEndpointGroup">						<xsd:annotation>							<xsd:documentation>If request has been proxied by an intermediate  aggregting system, trackng informattion relating to the original requestor. This allows the aggregation to be stateless.</xsd:documentation>						</xsd:annotation>					</xsd:group>					<xsd:sequence>						<xsd:group ref="CapabilityStatusGroup"/>					</xsd:sequence>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:complexType name="AbstractCapabilitiesStructure">		<xsd:annotation>			<xsd:documentation>Type for Capabilities of StopMonitopring Service.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="GeneralInteraction" type="CapabilityGeneralInteractionStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>General capabilities common to all SIRI service request types.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="TransportDescription" type="TransportDescriptionStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Implementation properties common to all request types.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:complexType name="CapabilityGeneralInteractionStructure">		<xsd:annotation>			<xsd:documentation>Type for Common Request Policy capabilities.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Interaction">				<xsd:annotation>					<xsd:documentation>Interaction capabilities.</xsd:documentation>				</xsd:annotation>				<xsd:complexType>					<xsd:sequence>						<xsd:element name="RequestResponse" type="xsd:boolean" default="true">							<xsd:annotation>								<xsd:documentation>Whether the service supports Request Response Interaction. Default is 'true'.</xsd:documentation>							</xsd:annotation>						</xsd:element>						<xsd:element name="PublishSubscribe" type="xsd:boolean" default="true">							<xsd:annotation>								<xsd:documentation>Whether the service supports Publish Subscribe Interaction. Default is 'true'.</xsd:documentation>							</xsd:annotation>						</xsd:element>					</xsd:sequence>				</xsd:complexType>			</xsd:element>			<xsd:element name="Delivery">				<xsd:annotation>					<xsd:documentation>Delivery capabilities.</xsd:documentation>				</xsd:annotation>				<xsd:complexType>					<xsd:sequence>						<xsd:element name="DirectDelivery" type="xsd:boolean">							<xsd:annotation>								<xsd:documentation>Whether the service supports Direct delivery.</xsd:documentation>							</xsd:annotation>						</xsd:element>						<xsd:element name="FetchedDelivery" type="xsd:boolean">							<xsd:annotation>								<xsd:documentation>Whether the service supports Fetched delivery (VDV Style)</xsd:documentation>							</xsd:annotation>						</xsd:element>					</xsd:sequence>				</xsd:complexType>			</xsd:element>			<xsd:element name="MultipartDespatch" type="xsd:boolean" default="true">				<xsd:annotation>					<xsd:documentation>Whether the service supports multiple part despatch with MoreData flag. Default is 'true'.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="MultipleSubscriberFilter" type="xsd:boolean" default="false">				<xsd:annotation>					<xsd:documentation>Whether the service supports multiple Subscriber Filters. Default is ' false'.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="HasConfirmDelivery" type="xsd:boolean" default="false">				<xsd:annotation>					<xsd:documentation>Whether the service supports Delivery confirm.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="HasHeartbeat" type="xsd:boolean" default="false">				<xsd:annotation>					<xsd:documentation>Whether the service has a heartbeat message. Default is 'false'.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="VisitNumberisOrder" type="xsd:boolean" default="false" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Whether VisitNumber can be used as a strict order number within JOURNEY PATTERN. Default is 'false'.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:complexType name="CapabilityRequestPolicyStructure">		<xsd:annotation>			<xsd:documentation>Type for Common Request Policy capabilities.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="NationalLanguage" type="xsd:language" maxOccurs="unbounded">				<xsd:annotation>					<xsd:documentation>National languages supported by service.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="Translations" type="xsd:boolean" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Whether producer can provide multiple  translations of NL text elements  +SIRI 2.0</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:choice>				<xsd:annotation>					<xsd:documentation>Default geospatial Coordinates used by service.</xsd:documentation>				</xsd:annotation>				<xsd:element name="GmlCoordinateFormat" type="SrsNameType">					<xsd:annotation>						<xsd:documentation>Name of GML Coordinate format used for Geospatial points in responses.</xsd:documentation>					</xsd:annotation>				</xsd:element>				<xsd:element name="WgsDecimalDegrees" type="EmptyType">					<xsd:annotation>						<xsd:documentation>Geospatial coordinates are given as Wgs 84 Latiude and longitude, decimial degrees of arc.</xsd:documentation>					</xsd:annotation>				</xsd:element>			</xsd:choice>		</xsd:sequence>	</xsd:complexType>	<xsd:complexType name="CapabilitySubscriptionPolicyStructure">		<xsd:annotation>			<xsd:documentation>Type for Common Subscription capabilities.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="HasIncrementalUpdates" type="xsd:boolean" default="true" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Whether incremental updates can be specified for updates Default is ' true'.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="HasChangeSensitivity" type="xsd:boolean" default="true" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Whether change threshold can be specified for updates. Default is 'true'.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<!-- ====Permissions================================================= -->	<xsd:complexType name="TransportDescriptionStructure">		<xsd:annotation>			<xsd:documentation>Type for implementation structure.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="CommunicationsTransportMethod" type="CommunicationsTransportMethodEnumeration" default="httpPost">				<xsd:annotation>					<xsd:documentation>Communications Transport method used to exchange messages. Default is 'httpPost'.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="CompressionMethod" type="CompressionMethodEnumeration" default="none">				<xsd:annotation>					<xsd:documentation>Compression method used to compress messages for transmission. Default is 'none'.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<!-- ====Discovery================================================ -->	<xsd:element name="AbstractDiscoveryRequest" type="AbstractDiscoveryRequestStructure" abstract="true" substitutionGroup="AuthenticatedRequest">		<xsd:annotation>			<xsd:documentation>Abstract Discovery request.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AbstractDiscoveryRequestStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Requests for stop reference data for use in service requests.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="RequestStructure">				<xsd:sequence>					<xsd:group ref="RequestorEndpointGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:element name="AbstractDiscoveryDelivery" type="AbstractDiscoveryDeliveryStructure" abstract="true" substitutionGroup="AbstractResponse">		<xsd:annotation>			<xsd:documentation>Abstract type for a discovery delivery.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AbstractDiscoveryDeliveryStructure">		<xsd:annotation>			<xsd:documentation>Abstract supertype fro discovery responses.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="ResponseStructure">				<xsd:sequence>					<xsd:group ref="DeliveryStatusGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_requests">
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>CEN TC278 WG3 SG7 Team</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG7 Editor Nicholas Knowles, Kizoom. mailto:schemer@siri.org.uk</Creator>
+				<Date>
+					<Created>2004-09-29</Created>
+				</Date>
+				<Date>
+					<Modified>2004-10-01</Modified>
+				</Date>
+				<Date>
+					<Modified>2005-02-14</Modified>
+				</Date>
+				<Date>
+					<Modified>2005-02-20</Modified>
+				</Date>
+				<Date>
+					<Modified>2005-05-11</Modified>
+				</Date>
+				<Date>
+					<Modified>2005-11-20</Modified>
+				</Date>
+				<Date>
+					<Modified>2007-03-29</Modified>
+				</Date>
+				<Date>
+					<Modified>2008-11-11</Modified>
+					 -- add substitution groups for 
+     AbstractRequest
+     AbstractResponse
+     AbstractFunctionalServiceRequest
+     AbstractFunctionalServiceSubscriptionRequest
+     AbstractFunctionalServiceDelivery
+     AbstractFunctionalServiceCapabilityRequest
+     AbstractFunctionalServiceCapabilityDelivery
+     AbstractDiscoveryDelivery
+     ErrorCode
+     
+				</Date>
+				<Date>
+					<Modified>2008-11-13</Modified>
+					 Move abstract discovery deliveries to here from siri_discoveries 
+				</Date>
+				<Date>
+					<Modified>2008-11-17</Modified>
+					 -- Add abstract discovery request 
+       Make request and response descendent of Request and Response Types 
+				</Date>
+				<Date>
+					<Modified>2009-03-31</Modified>
+					 - Add ErrorConditionelement to enable WSDL axis binding 
+				</Date>
+				<Date>
+					<Modified>2011-04-18</Modified>
+					 - ErrorConditionStructure Line 841 should not be abstract. Fix from RV ixxi.biz
+						 Also Add ServiceConditionErrorConditionElement 
+				</Date>
+				<Date>
+					<Modified>2012-03-23</Modified>
+					 +SIRI v2.0
+					  Add error number to Error structure
+					  factor out base identifier defintiiosn so can be share dwith error codes
+					  Factor out error codes
+					  Factor our Permission model to separate package siri_permissions
+				</Date>
+				<Date>
+					<Modified>2012-06-17</Modified>
+					 +SIRI v2.0 x
+					  Add delegator endpoint group to ServceRequest and FunctionalServcieResponse
+				</Date>
+				<Date>
+					<Modified>2013-02-11</Modified>
+					Added AbstractRequiredIdentifiedItemStructure
+					Added AbstractRequiredReferencingItemStructure
+				</Date>
+				<Date>
+					<Modified>2014-07-12</Modified>
+					Structure
+					Added AbstractRequiredReferencingItemStructure
+				</Date>
+				<Description>
+					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common request processing elements</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri/}siri_requests-v2.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>
+				<Relation>
+					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_types-v2.0.xsd</Requires>
+				</Relation>
+				<Rights>Unclassified
+
+        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the VDV, RTIGXML and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 2.0 Draft</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,
+Rail transport, Roads and road transport
+</Category>
+					<Project>CEN TC278 WG3 SG7</Project>
+				</Subject>
+				<Title>SIRI XML schema. Common Request elements. </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SIRI Common Request Framework.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:include schemaLocation="../siri_utility/siri_utility-v1.1.xsd"/>
+	<xsd:include schemaLocation="../siri_utility/siri_location-v2.0.xsd"/>
+	<xsd:include schemaLocation="siri_request_errorConditions-v2.0.xsd"/>
+	<!-- ======================================================================= -->
+	<!-- ======================================================================= -->
+	<xsd:element name="AbstractRequest" type="AbstractRequestStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a timestamped SIRI request.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AbstractRequestStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for General SIRI Request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="RequestTimestamp"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="AuthenticatedRequest" type="AuthenticatedRequestStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for an authenticated request Authenticated.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AuthenticatedRequestStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for Authticated SIRI Request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractRequestStructure">
+				<xsd:group ref="AuthenticatedRequestGroup"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="AuthenticatedRequestGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elemenst for authecticiation. +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="AccountId" type="xsd:NMTOKEN" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Account Identifier. May be used to attribute requests to a particular application provider and authentication key. The account  may be common to all users of an application, or to an individual user. Note that to identify an individual user the  RequestorRef can be used with an anonymised token.  .     +SIRI v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="AccountKey" type="xsd:normalizedString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Authentication key for request. May be used to authenticate requests from a particular account. +SIRI v2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="RequestStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for General SIRI Request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AuthenticatedRequestStructure">
+				<xsd:sequence>
+					<xsd:group ref="RequestorEndpointGroup"/>
+					<xsd:group ref="DelegatorEndpointGroup">
+						<xsd:annotation>
+							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="RequestorEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements relating to system that sent request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Address to which response is to be sent. This may also be determined from RequestorRef and preconfigured data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="RequestorRef"/>
+			<xsd:element name="MessageIdentifier" type="MessageQualifierStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Arbitrary unique identifier that can be used to reference this message in subsequent interactions.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="DelegatorEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking informattion relating to the original requestor. This allows the aggregation to be stateless.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="DelegatorAddress" type="EndpointAddress" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Address of original Consumer, i.e. requesting system to which delegating response is to be  returned. +SIRI 2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="DelegatorRef" type="ParticipantRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Identifier of delegating system that originated message. +SIRI 2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="AbstractTrackedRequest" type="RequestStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a SIRI request with requestor dteials tracked.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!-- ======================================================================= -->
+	<xsd:element name="AbstractServiceRequest" type="AbstractServiceRequestStructure" abstract="true" substitutionGroup="AbstractRequest">
+		<xsd:annotation>
+			<xsd:documentation>Substitutable type for a SIRI Functional Service request.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AbstractServiceRequestStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Abstract Service Request for SIRI Service request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractRequestStructure">
+				<xsd:sequence>
+					<xsd:group ref="ContextualisedRequestEndpointGroup">
+						<xsd:annotation>
+							<xsd:documentation>Unique reference to request: participant and SIRI service type are given by context. Used on requests that are embedded in the context of another request. Only a message identfiier may be needed.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ContextualisedRequestEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Unique reference to request: participant and SIRI service type are given by context. Used on requests that are embedded in the context of another request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="MessageIdentifier" type="MessageQualifierStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Arbitrary unique reference to this message.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:element name="AbstractFunctionalServiceRequest" type="AbstractFunctionalServiceRequestStructure" abstract="true" substitutionGroup="AbstractServiceRequest">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a SIRI Functional Service request.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AbstractFunctionalServiceRequestStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Abstract Service Request for SIRI Service request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractServiceRequestStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ===Request Context================================================================== -->
+	<xsd:complexType name="AbstractSubscriptionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for SIRI Service subscriptions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="SubscriptionIdentityGroup"/>
+			<xsd:element name="InitialTerminationTime" type="xsd:dateTime">
+				<xsd:annotation>
+					<xsd:documentation>Requested end time for subscription.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="AbstractFunctionalServiceSubscriptionRequest" type="AbstractSubscriptionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a SIRI Functional Service subscription request.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:group name="SubscriptionIdentityGroup">
+		<xsd:annotation>
+			<xsd:documentation>Type for unique identifier of a subscription.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SubscriberRef" type="ParticipantRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Participant identifier of Subscriber. Normally this will be given by context, i.e. be the same as on the Subscription Request.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="SubscriptionIdentifier" type="SubscriptionQualifierStructure">
+				<xsd:annotation>
+					<xsd:documentation>Identifier to be given to Subscription.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="SubscriptionContextStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Subscription context - Configuration parameters which may be evrriden.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="HeartbeatInterval" type="PositiveDurationType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Interval for heartbeat.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractSubscriptionRequestStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for COmmon Subscription Request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="RequestStructure">
+				<xsd:sequence>
+					<xsd:group ref="SubscriberEndpointGroup"/>
+					<xsd:element name="SubscriptionContext" type="SubscriptionContextStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>General values that apply to subscription. Usually set by configuration.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="AbstractResponse" type="ResponseStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a SIRI response.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ResponseStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>General Type for General SIRI Response.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="ResponseTimestamp"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:group name="ServiceDeliveryRequestStatusGroup">
+		<xsd:annotation>
+			<xsd:documentation>Status Information for overall request. Specific error conditions will be given on each individual request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Status" type="xsd:boolean" default="true" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether the complerte request could be processed successfully or not. Default is 'true'. If any of the individual requests within the delivery failed, should be set to ' false'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ErrorCondition" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of any error or warning conditions that appluy to the overall request. More Specific error conditions should be included on each request that fails.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:choice>
+							<xsd:element ref="CapabilityNotSupportedError"/>
+							<xsd:element ref="OtherError"/>
+						</xsd:choice>
+						<xsd:element name="Description" type="ErrorDescriptionStructure" minOccurs="0">
+							<xsd:annotation>
+								<xsd:documentation>Text description of error.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:element name="ProducerResponse" type="ProducerResponseStructure" abstract="true" substitutionGroup="AbstractResponse">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a SIRI r Producer esponse.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ProducerResponseStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for General SIRI Producer Response.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ResponseStructure">
+				<xsd:sequence>
+					<xsd:group ref="ProducerResponseEndpointGroup"/>
+					<xsd:group ref="DelegatorEndpointGroup">
+						<xsd:annotation>
+							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeliveryStatusGroup">
+		<xsd:annotation>
+			<xsd:documentation>Status Information for individual request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="Status" minOccurs="0"/>
+			<xsd:element name="ErrorCondition" type="ServiceDeliveryErrorConditionStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of any error or warning condition.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:group ref="SuccessInfoGroup"/>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="AbstractNotificationStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for Notification Request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ProducerRequestEndpointStructure"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:element name="AbstractFunctionalServiceDelivery" type="AbstractServiceDeliveryStructure" abstract="true" substitutionGroup="AbstractResponse">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a SIRI Functional Service Deivery.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AbstractServiceDeliveryStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for Common elementd for a SIRI service delivery of the Form xxxDelivery.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ResponseStructure">
+				<xsd:sequence>
+					<xsd:choice>
+						<xsd:group ref="ContextualisedResponseEndpointGroup"/>
+						<xsd:group ref="SubscriptionIdentifierResourcePropertyGroup"/>
+					</xsd:choice>
+					<xsd:group ref="DelegatorEndpointGroup">
+						<xsd:annotation>
+							<xsd:documentation>If request has been proxied by an intermediate  aggregting system, trackng informattion relating to the original requestor. This allows the aggregation to be stateless.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+					<xsd:group ref="DeliveryStatusGroup"/>
+					<xsd:group ref="DeliveryDefaultGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="DeliveryDefaultGroup">
+		<xsd:annotation>
+			<xsd:documentation>Common defaults.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="DefaultLanguage" type="xsd:language" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Default language for text elements.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="SubscriberEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Unique reference to request. May be used to reference request in subsequent interactions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="ConsumerAddress" type="EndpointAddress" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Address to which data is to be sent, if different from Address. This may also be determined from RequestorRef and preconfigured data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="SubscriptionFilterIdentifier" type="xsd:NMTOKEN" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a Subscription Filter with which this subscription is to be aggregated for purposes of notification and delivery. If absent, use the default filter. If present, use any existing filter with that identifier, if none found, create a new one. Optional SIRI feature.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="SubscriptionIdentifierResourcePropertyGroup">
+		<xsd:annotation>
+			<xsd:documentation>Unique reference to subscription May be used to reference subscription in subsequent interactions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SubscriberRef" type="ParticipantRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Unique identifier of Subscriber - reference to a Participant.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="SubscriptionFilterRef" type="SubscriptionFilterRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Unique identifier of Subscription filter to which this subscription is assigned. If there is onlya single filter, then can be omitted.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="SubscriptionRef" type="SubscriptionQualifierStructure">
+				<xsd:annotation>
+					<xsd:documentation>Reference to a service subscription: unique within Service and Subscriber.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="OptionalSubscriberEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Unique reference to subscription May be used to reference subscription in subsequent interactions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SubscriberRef" type="ParticipantRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>If Delivery is for a Subscription, Participant reference of Subscriber.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="SubscriptionRef" type="SubscriptionQualifierStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>If Delivery is for a Subscription, unique identifier of service subscription request within Service and subscriber - a Timestamp.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="ContextualisedResponseEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Endpoint reference proprerties for response message: participant and SIRI service type are given by context.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="RequestMessageRef" type="MessageQualifierStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Arbitrary unique reference to the request which gave rise to this message.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:element name="Status" type="xsd:boolean" default="true">
+		<xsd:annotation>
+			<xsd:documentation>Whether the request was processed successfully or not. Default is 'true'.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!-- ============WSDL========================================================= -->
+	<xsd:complexType name="ConsumerRequestEndpointStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Unique reference to this request, created by Consumer. May be used to reference the request in subsequent interactions. Used by WSDL.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AuthenticatedRequestStructure">
+				<xsd:sequence>
+					<xsd:group ref="ConsumerRequestEndpointGroup"/>
+					<xsd:group ref="DelegatorEndpointGroup">
+						<xsd:annotation>
+							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ConsumerRequestEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Unique reference to this request, created by Consumer. May be used to reference the request in subsequent interactions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Address to which response is to be sent. This may also be determined from RequestorRef and preconfigured data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ConsumerRef" type="ParticipantRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Unique identifier of Consumer - a Participant reference.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="MessageIdentifier" type="MessageQualifierStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Arbitrary unique reference to this message. Some systems may use just timestamp for this.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="ConsumerResponseEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Unique reference to this response message from Consumer. May be used to reference the response in subsequent interactions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="ConsumerRef" type="ParticipantRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Unique identifier of Consumer - a Participant reference.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="RequestMessageRef" type="MessageRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to an arbitrary unique idenitifer associated with the request which gave rise to this response.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="ConsumerResponseEndpointStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Unique reference to this response created by Consumer. May be used to reference the request in subsequent interactions. Used by WSDL.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ResponseStructure">
+				<xsd:sequence>
+					<xsd:group ref="ConsumerResponseEndpointGroup"/>
+					<xsd:group ref="DelegatorEndpointGroup">
+						<xsd:annotation>
+							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ============WSDL========================================================= -->
+	<xsd:element name="ProducerRequest" type="ProducerRequestEndpointStructure" abstract="true" substitutionGroup="AuthenticatedRequest"/>
+	<xsd:complexType name="ProducerRequestEndpointStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Unique reference to request to the producer. May be used to reference request in subsequent interactions. Used for WSDL.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AuthenticatedRequestStructure">
+				<xsd:sequence>
+					<xsd:group ref="ProducerRequestEndpointGroup"/>
+					<xsd:group ref="DelegatorEndpointGroup">
+						<xsd:annotation>
+							<xsd:documentation>If request has been proxied by an intermediate  aggregting system, trackng informattion relating to the original requestor. This allows the aggregation to be stateless.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ProducerRequestEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Unique reference to request from producer. May be used to reference request in subsequent interactions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Address to which response is to be sent. This may also be determined from ProducerRef and preconfigured data.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ProducerRef" type="ParticipantRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Unique identifier of Producer - Participant reference.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="MessageIdentifier" type="MessageQualifierStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Arbitrary unique reference to this message. Some systems may use just timestamp for this. Where there are multiple SubscriptionFilters, this can be used to distinguish between different notifications for different filters.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:group name="ResponseEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Unique reference to response May be used to reference response in subsequent interactions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Address for further interaction.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ResponderRef" type="ParticipantRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Participant reference that identifies responder.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="RequestMessageRef" type="MessageQualifierStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to an arbitrary unique reference associated with the request which gave rise to this response.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="ResponseEndpointStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Unique reference to reponse. May be used to reference request in subsequent interactions. Used for WSDL 
+
+ .</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ResponseStructure">
+				<xsd:sequence>
+					<xsd:group ref="ResponseEndpointGroup"/>
+					<xsd:group ref="DelegatorEndpointGroup">
+						<xsd:annotation>
+							<xsd:documentation>If request has been proxied by an intermediate  aggregating system , tracking information relating to the original requestor. This allows the aggregation to be stateless. +SIRI 2.0</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ProducerResponseEndpointGroup">
+		<xsd:annotation>
+			<xsd:documentation>Unique reference to reponse from producer. May be used to reference request in subsequent interactions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="ProducerRef" type="ParticipantRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Unique identifier of Producer - Participant reference.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Address" type="EndpointAddress" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Endpoint Address to which acknowledgements to confirm delivery are to be sent.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ResponseMessageIdentifier" type="MessageQualifierStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>An arbitrary unique reference associated with the response which may be used to reference it.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="RequestMessageRef" type="MessageRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Reference to an arbitrary unique identifier associated with the request which gave rise to this response.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="ProducerResponseEndpointStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Unique reference to reponse from producer. May be used to reference request in subsequent interactions. Used for WSDL.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ResponseStructure">
+				<xsd:sequence>
+					<xsd:group ref="ProducerResponseEndpointGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ============Recorded Items========================================================== -->
+	<xsd:complexType name="AbstractItemStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for an Activity.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="RecordedAtTime" type="xsd:dateTime">
+				<xsd:annotation>
+					<xsd:documentation>Time at which data was recorded.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractIdentifiedItemStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for an Activity that can be referenced.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractItemStructure">
+				<xsd:sequence>
+					<xsd:element name="ItemIdentifier" type="ItemIdentifierType" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of item.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractRequiredIdentifiedItemStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for an Activity that can be referenced.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractItemStructure">
+				<xsd:sequence>
+					<xsd:element name="ItemIdentifier" type="ItemIdentifierType">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of item.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractReferencingItemStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for an Activity that references a previous Activity.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractItemStructure">
+				<xsd:sequence>
+					<xsd:element name="ItemRef" type="ItemRefStructure" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Reference to an Activity Element of  a delivery.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractRequiredReferencingItemStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for an Activity that references a previous Activity.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractItemStructure">
+				<xsd:sequence>
+					<xsd:element name="ItemRef" type="ItemRefStructure">
+						<xsd:annotation>
+							<xsd:documentation>Reference to an Activity Element of  a delivery.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<!-- ======================================================================= -->
+	<xsd:element name="AbstractFunctionalServiceCapabilitiesRequest" type="AbstractServiceRequestStructure" abstract="true" substitutionGroup="AbstractServiceRequest">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a SIRI Functional Service Capabiloities equest.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ServiceCapabilitiesRequestStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for ServcieCapabilities request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AbstractServiceRequestStructure">
+				<xsd:sequence>
+					<xsd:element name="ParticipantPermissions" type="xsd:boolean" default="false" minOccurs="0">
+						<xsd:annotation>
+							<xsd:documentation>Whether to include the requestors permissions in the response. Only applies if Access control capability supported. Default is 'false'.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element ref="Extensions" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="version" type="VersionString" default="2.0">
+					<xsd:annotation>
+						<xsd:documentation>Version number of request. Fixed.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="CapabilityStatusGroup">
+		<xsd:annotation>
+			<xsd:documentation>Status Information for individual request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="Status" minOccurs="0"/>
+			<xsd:element name="ErrorCondition" type="ServiceDeliveryErrorConditionStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Description of any error or warning condition.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+	<xsd:element name="AbstractFunctionalServiceCapabilitiesResponse" type="AbstractServiceCapabilitiesResponseStructure" abstract="true" substitutionGroup="AbstractResponse">
+		<xsd:annotation>
+			<xsd:documentation>Subsititutable type for a SIRI Functional Service Capabilities Response.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AbstractServiceCapabilitiesResponseStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for capabilities response.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ResponseStructure">
+				<xsd:sequence>
+					<xsd:group ref="ContextualisedResponseEndpointGroup"/>
+					<xsd:group ref="DelegatorEndpointGroup">
+						<xsd:annotation>
+							<xsd:documentation>If request has been proxied by an intermediate  aggregting system, trackng informattion relating to the original requestor. This allows the aggregation to be stateless.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:group>
+					<xsd:sequence>
+						<xsd:group ref="CapabilityStatusGroup"/>
+					</xsd:sequence>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="AbstractCapabilitiesStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Capabilities of StopMonitopring Service.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="GeneralInteraction" type="CapabilityGeneralInteractionStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>General capabilities common to all SIRI service request types.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="TransportDescription" type="TransportDescriptionStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Implementation properties common to all request types.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CapabilityGeneralInteractionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Common Request Policy capabilities.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Interaction">
+				<xsd:annotation>
+					<xsd:documentation>Interaction capabilities.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="RequestResponse" type="xsd:boolean" default="true">
+							<xsd:annotation>
+								<xsd:documentation>Whether the service supports Request Response Interaction. Default is 'true'.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="PublishSubscribe" type="xsd:boolean" default="true">
+							<xsd:annotation>
+								<xsd:documentation>Whether the service supports Publish Subscribe Interaction. Default is 'true'.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="Delivery">
+				<xsd:annotation>
+					<xsd:documentation>Delivery capabilities.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="DirectDelivery" type="xsd:boolean">
+							<xsd:annotation>
+								<xsd:documentation>Whether the service supports Direct delivery.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="FetchedDelivery" type="xsd:boolean">
+							<xsd:annotation>
+								<xsd:documentation>Whether the service supports Fetched delivery (VDV Style)</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="MultipartDespatch" type="xsd:boolean" default="true">
+				<xsd:annotation>
+					<xsd:documentation>Whether the service supports multiple part despatch with MoreData flag. Default is 'true'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="MultipleSubscriberFilter" type="xsd:boolean" default="false">
+				<xsd:annotation>
+					<xsd:documentation>Whether the service supports multiple Subscriber Filters. Default is ' false'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="HasConfirmDelivery" type="xsd:boolean" default="false">
+				<xsd:annotation>
+					<xsd:documentation>Whether the service supports Delivery confirm.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="HasHeartbeat" type="xsd:boolean" default="false">
+				<xsd:annotation>
+					<xsd:documentation>Whether the service has a heartbeat message. Default is 'false'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="VisitNumberisOrder" type="xsd:boolean" default="false" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether VisitNumber can be used as a strict order number within JOURNEY PATTERN. Default is 'false'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CapabilityRequestPolicyStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Common Request Policy capabilities.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="NationalLanguage" type="xsd:language" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>National languages supported by service.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Translations" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether producer can provide multiple  translations of NL text elements  +SIRI 2.0</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:choice>
+				<xsd:annotation>
+					<xsd:documentation>Default geospatial Coordinates used by service.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:element name="GmlCoordinateFormat" type="SrsNameType">
+					<xsd:annotation>
+						<xsd:documentation>Name of GML Coordinate format used for Geospatial points in responses.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="WgsDecimalDegrees" type="EmptyType">
+					<xsd:annotation>
+						<xsd:documentation>Geospatial coordinates are given as Wgs 84 Latiude and longitude, decimial degrees of arc.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CapabilitySubscriptionPolicyStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Common Subscription capabilities.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="HasIncrementalUpdates" type="xsd:boolean" default="true" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether incremental updates can be specified for updates Default is ' true'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="HasChangeSensitivity" type="xsd:boolean" default="true" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Whether change threshold can be specified for updates. Default is 'true'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- ====Permissions================================================= -->
+	<xsd:complexType name="TransportDescriptionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for implementation structure.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="CommunicationsTransportMethod" type="CommunicationsTransportMethodEnumeration" default="httpPost">
+				<xsd:annotation>
+					<xsd:documentation>Communications Transport method used to exchange messages. Default is 'httpPost'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="CompressionMethod" type="CompressionMethodEnumeration" default="none">
+				<xsd:annotation>
+					<xsd:documentation>Compression method used to compress messages for transmission. Default is 'none'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- ====Discovery================================================ -->
+	<xsd:element name="AbstractDiscoveryRequest" type="AbstractDiscoveryRequestStructure" abstract="true" substitutionGroup="AuthenticatedRequest">
+		<xsd:annotation>
+			<xsd:documentation>Abstract Discovery request.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AbstractDiscoveryRequestStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Requests for stop reference data for use in service requests.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="RequestStructure">
+				<xsd:sequence>
+					<xsd:group ref="RequestorEndpointGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="AbstractDiscoveryDelivery" type="AbstractDiscoveryDeliveryStructure" abstract="true" substitutionGroup="AbstractResponse">
+		<xsd:annotation>
+			<xsd:documentation>Abstract type for a discovery delivery.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AbstractDiscoveryDeliveryStructure">
+		<xsd:annotation>
+			<xsd:documentation>Abstract supertype fro discovery responses.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="ResponseStructure">
+				<xsd:sequence>
+					<xsd:group ref="DeliveryStatusGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/schema/1.03/xsd/siri_utility/siri_location-v2.0.xsd
+++ b/schema/1.03/xsd/siri_utility/siri_location-v2.0.xsd
@@ -1,1 +1,242 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_location">	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor>CEN TC278 WG3 SG9 Team.</Contributor>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>				<Date>					<Created>2004-09-29</Created>				</Date>				<Date>					<Modified>2004-10-01</Modified>				</Date>				<Date>					<Modified>2005-02-14</Modified>				</Date>				<Date>					<Modified>2005-05-11</Modified>				</Date>				<Date>					<Modified>2005-05-04</Modified>				</Date>				<Date>					<Modified>2007-03-29</Modified>				</Date>				<Date>					<Modified>2012-03-23</Modified>					 +SIRI v2.0					  Add VelocityType 					  Add bounding box for use by StopPoints discovery				</Date>				<Date>					<Modified>2012-05-10</Modified>					 +SIRI v2.0 					  Add Line Shape  by Lines  discovery				</Date>				<Description>					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines geospatial location elements</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utility/}siri_location-v2.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>CEN</Publisher>				<Rights>Unclassified        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the VDV, RTIG XML and Trident standards.</li>					</ul>				</Source>				<Status>Version 2.0 Draft</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,Rail transport, Roads and road transport</Category>				<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>SIRI XML schema. Geo spatial location subschema </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SIRI Framewrok Location Types.</xsd:documentation>	</xsd:annotation>	<!--======WGS84=======================================================================================-->	<xsd:simpleType name="LongitudeType">		<xsd:annotation>			<xsd:documentation>Longitude from Greenwich.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:decimal">			<xsd:minInclusive value="-180"/>			<xsd:maxInclusive value="180"/>		</xsd:restriction>	</xsd:simpleType>	<xsd:simpleType name="LatitudeType">		<xsd:annotation>			<xsd:documentation>Latitude from equator.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:decimal">			<xsd:minInclusive value="-90"/>			<xsd:maxInclusive value="90"/>		</xsd:restriction>	</xsd:simpleType>	<xsd:simpleType name="AltitudeType">		<xsd:annotation>			<xsd:documentation>Altitude metres from sea level.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:decimal">			<xsd:minInclusive value="-1000"/>			<xsd:maxInclusive value="+5000"/>		</xsd:restriction>	</xsd:simpleType>	<xsd:group name="WgsGroup">		<xsd:annotation>			<xsd:documentation>WGS84 Coordinates.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Longitude" type="LongitudeType">				<xsd:annotation>					<xsd:documentation>Longitude from Greenwich Meridian. -180 (East) to +180 (West).</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="Latitude" type="LatitudeType">				<xsd:annotation>					<xsd:documentation>Latitude from equator. -90 (South) to +90 (North).</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="Altitude" type="AltitudeType" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Altitude.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<xsd:complexType name="CoordinatesStructure">		<xsd:annotation>			<xsd:documentation>Type for GM Coordinates.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="xsd:NMTOKENS"/>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="SrsNameType">		<xsd:annotation>			<xsd:documentation>Type for coordinate reference system.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:string"/>	</xsd:simpleType>	<xsd:element name="SrsName" type="SrsNameType">		<xsd:annotation>			<xsd:documentation>GML Spatial coordinate reference system.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<!--====== LOCATIONe ============================================================-->	<xsd:complexType name="LocationStructure">		<xsd:annotation>			<xsd:documentation>Type for gepspatial Position of a point. May be expressed in concrete WGS 84 Coordinates or any gml compatible point coordinates format.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:choice>				<xsd:sequence>					<xsd:element name="Longitude" type="LongitudeType">						<xsd:annotation>							<xsd:documentation>Longitude from Greenwich Meridian. -180 (West) to +180 (East). Decimal degrees. eg 2.356</xsd:documentation>						</xsd:annotation>					</xsd:element>					<xsd:element name="Latitude" type="LatitudeType">						<xsd:annotation>							<xsd:documentation>Latitude from equator. -90 (South) to +90 (North). Decimal degrees. eg 56.356</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>				<xsd:element name="Coordinates" type="CoordinatesStructure">					<xsd:annotation>						<xsd:documentation>Coordinates of points in a GML compatibe format, as indicated by srsName attribute.</xsd:documentation>					</xsd:annotation>				</xsd:element>			</xsd:choice>			<xsd:element name="Precision" type="DistanceType" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Precision for point measurement. In meters.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>		<xsd:attribute name="id" type="xsd:NMTOKEN">			<xsd:annotation>				<xsd:documentation>Identifier of POINT.</xsd:documentation>			</xsd:annotation>		</xsd:attribute>		<xsd:attribute name="srsName" type="SrsNameType">			<xsd:annotation>				<xsd:documentation>identifier of data reference system for geocodes if point is specified as gml compatible Coordinates. A gml value. If not specified taken from system configuration.</xsd:documentation>			</xsd:annotation>		</xsd:attribute>	</xsd:complexType>	<xsd:complexType name="BoundingBoxStructure">		<xsd:annotation>			<xsd:documentation>Defines a bounding box using two corner points. GML terminology.  +SIRI v2.0</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="UpperLeft" type="LocationStructure">				<xsd:annotation>					<xsd:documentation>A geospatial point. Upper Left corner..</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="LowerRight" type="LocationStructure">				<xsd:annotation>					<xsd:documentation>A geospatial point. Lower right corner..</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:complexType name="LineShapeStructure">		<xsd:annotation>			<xsd:documentation>Defines a line shape +SIRI v2.0</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Point" type="LocationStructure" minOccurs="2" maxOccurs="unbounded">				<xsd:annotation>					<xsd:documentation>A geospatial point. +SIRI v2.0 .</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<!--======Distance ============================================================-->	<xsd:simpleType name="DistanceType">		<xsd:annotation>			<xsd:documentation>Distance (metres) as defined by http://www.ordnancesurvey.co.uk/xml/resource/units.xml#metres. ALternative units may be specifed by context.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:nonNegativeInteger"/>	</xsd:simpleType>	<xsd:simpleType name="VelocityType">		<xsd:annotation>			<xsd:documentation>Distance (metres per second) ALternative unist may be specifed by context.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:nonNegativeInteger"/>	</xsd:simpleType>	<xsd:simpleType name="AbsoluteBearingType">		<xsd:annotation>			<xsd:documentation>Type for absolute bearing.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:float"/>	</xsd:simpleType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_location">
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>CEN TC278 WG3 SG9 Team.</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>
+				<Date>
+					<Created>2004-09-29</Created>
+				</Date>
+				<Date>
+					<Modified>2004-10-01</Modified>
+				</Date>
+				<Date>
+					<Modified>2005-02-14</Modified>
+				</Date>
+				<Date>
+					<Modified>2005-05-11</Modified>
+				</Date>
+				<Date>
+					<Modified>2005-05-04</Modified>
+				</Date>
+				<Date>
+					<Modified>2007-03-29</Modified>
+				</Date>
+				<Date>
+					<Modified>2012-03-23</Modified>
+					 +SIRI v2.0
+					  Add VelocityType 
+					  Add bounding box for use by StopPoints discovery
+				</Date>
+				<Date>
+					<Modified>2012-05-10</Modified>
+					 +SIRI v2.0 
+					  Add Line Shape  by Lines  discovery
+				</Date>
+				<Description>
+					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines geospatial location elements</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utility/}siri_location-v2.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>CEN</Publisher>
+				<Rights>Unclassified
+        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the VDV, RTIG XML and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 2.0 Draft</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,
+Rail transport, Roads and road transport
+</Category>
+				<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>SIRI XML schema. Geo spatial location subschema </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SIRI Framewrok Location Types.</xsd:documentation>
+	</xsd:annotation>
+	<!--======WGS84=======================================================================================-->
+	<xsd:simpleType name="LongitudeType">
+		<xsd:annotation>
+			<xsd:documentation>Longitude from Greenwich.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:decimal">
+			<xsd:minInclusive value="-180"/>
+			<xsd:maxInclusive value="180"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="LatitudeType">
+		<xsd:annotation>
+			<xsd:documentation>Latitude from equator.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:decimal">
+			<xsd:minInclusive value="-90"/>
+			<xsd:maxInclusive value="90"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="AltitudeType">
+		<xsd:annotation>
+			<xsd:documentation>Altitude metres from sea level.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:decimal">
+			<xsd:minInclusive value="-1000"/>
+			<xsd:maxInclusive value="+5000"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:group name="WgsGroup">
+		<xsd:annotation>
+			<xsd:documentation>WGS84 Coordinates.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Longitude" type="LongitudeType">
+				<xsd:annotation>
+					<xsd:documentation>Longitude from Greenwich Meridian. -180 (East) to +180 (West).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Latitude" type="LatitudeType">
+				<xsd:annotation>
+					<xsd:documentation>Latitude from equator. -90 (South) to +90 (North).</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Altitude" type="AltitudeType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Altitude.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<xsd:complexType name="CoordinatesStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for GM Coordinates.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:NMTOKENS"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SrsNameType">
+		<xsd:annotation>
+			<xsd:documentation>Type for coordinate reference system.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string"/>
+	</xsd:simpleType>
+	<xsd:element name="SrsName" type="SrsNameType">
+		<xsd:annotation>
+			<xsd:documentation>GML Spatial coordinate reference system.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!--====== LOCATIONe ============================================================-->
+	<xsd:complexType name="LocationStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for gepspatial Position of a point. May be expressed in concrete WGS 84 Coordinates or any gml compatible point coordinates format.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:sequence>
+					<xsd:element name="Longitude" type="LongitudeType">
+						<xsd:annotation>
+							<xsd:documentation>Longitude from Greenwich Meridian. -180 (West) to +180 (East). Decimal degrees. eg 2.356</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="Latitude" type="LatitudeType">
+						<xsd:annotation>
+							<xsd:documentation>Latitude from equator. -90 (South) to +90 (North). Decimal degrees. eg 56.356</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:element name="Coordinates" type="CoordinatesStructure">
+					<xsd:annotation>
+						<xsd:documentation>Coordinates of points in a GML compatibe format, as indicated by srsName attribute.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
+			<xsd:element name="Precision" type="DistanceType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Precision for point measurement. In meters.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:NMTOKEN">
+			<xsd:annotation>
+				<xsd:documentation>Identifier of POINT.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="srsName" type="SrsNameType">
+			<xsd:annotation>
+				<xsd:documentation>identifier of data reference system for geocodes if point is specified as gml compatible Coordinates. A gml value. If not specified taken from system configuration.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:complexType name="BoundingBoxStructure">
+		<xsd:annotation>
+			<xsd:documentation>Defines a bounding box using two corner points. GML terminology.  +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="UpperLeft" type="LocationStructure">
+				<xsd:annotation>
+					<xsd:documentation>A geospatial point. 
+Upper Left corner.
+.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="LowerRight" type="LocationStructure">
+				<xsd:annotation>
+					<xsd:documentation>A geospatial point. 
+Lower right corner.
+.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="LineShapeStructure">
+		<xsd:annotation>
+			<xsd:documentation>Defines a line shape +SIRI v2.0</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Point" type="LocationStructure" minOccurs="2" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>A geospatial point. +SIRI v2.0 
+
+.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!--======Distance ============================================================-->
+	<xsd:simpleType name="DistanceType">
+		<xsd:annotation>
+			<xsd:documentation>Distance (metres) as defined by http://www.ordnancesurvey.co.uk/xml/resource/units.xml#metres. ALternative units may be specifed by context.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:nonNegativeInteger"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="VelocityType">
+		<xsd:annotation>
+			<xsd:documentation>Distance (metres per second) ALternative unist may be specifed by context.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:nonNegativeInteger"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="AbsoluteBearingType">
+		<xsd:annotation>
+			<xsd:documentation>Type for absolute bearing.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:float"/>
+	</xsd:simpleType>
+</xsd:schema>

--- a/schema/1.03/xsd/siri_utility/siri_participant-v2.0.xsd
+++ b/schema/1.03/xsd/siri_utility/siri_participant-v2.0.xsd
@@ -1,1 +1,81 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_participant">	<!-- ======================================================================= -->	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor>CEN TC278 WG3 SG9 Team.</Contributor>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>				<Date>					<Created>2004-09-29</Created>				</Date>				<Date>					<Modified>2007-05-15</Modified>				</Date>				<Date>					<Modified>2008-07-015</Modified>					 drop  use of partipant pair 				</Date>				<Date>					<Modified>2012-03-22</Modified>				SIRI 2.0 					Move  Capability 				</Date>				<Description>					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common Participant type elements</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utility/}siri_participant-v2.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>				<Rights>Unclassified        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the VDV, RTIGXML and Trident standards.</li>					</ul>				</Source>				<Status>Version 2.0 Draft</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,Rail transport, Roads and road transport</Category>				<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>SIRI XML schema. Participant type elements. </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SIRI Framework Participant Types.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:simpleType name="ParticipantCodeType">		<xsd:annotation>			<xsd:documentation>Type for Unique identifier of participant.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN"/>	</xsd:simpleType>	<xsd:complexType name="ParticipantRefStructure">		<xsd:annotation>			<xsd:documentation>Reference to Unique identifier of participant.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="ParticipantCodeType"/>		</xsd:simpleContent>	</xsd:complexType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_participant">
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>CEN TC278 WG3 SG9 Team.</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>
+				<Date>
+					<Created>2004-09-29</Created>
+				</Date>
+				<Date>
+					<Modified>2007-05-15</Modified>
+				</Date>
+				<Date>
+					<Modified>2008-07-015</Modified>
+					 drop  use of partipant pair 
+
+				</Date>
+				<Date>
+					<Modified>2012-03-22</Modified>
+				SIRI 2.0 
+					Move  Capability 
+				</Date>
+				<Description>
+					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common Participant type elements</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utility/}siri_participant-v2.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>
+				<Rights>Unclassified
+
+        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the VDV, RTIGXML and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 2.0 Draft</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,
+Rail transport, Roads and road transport
+</Category>
+				<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>SIRI XML schema. Participant type elements. </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SIRI Framework Participant Types.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="ParticipantCodeType">
+		<xsd:annotation>
+			<xsd:documentation>Type for Unique identifier of participant.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN"/>
+	</xsd:simpleType>
+	<xsd:complexType name="ParticipantRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Reference to Unique identifier of participant.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="ParticipantCodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+</xsd:schema>

--- a/schema/1.03/xsd/siri_utility/siri_permissions-v2.0.xsd
+++ b/schema/1.03/xsd/siri_utility/siri_permissions-v2.0.xsd
@@ -1,1 +1,136 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_permissions">	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor>CEN TC278 WG3 SG9 Team.</Contributor>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 2.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>				<Date>					<Created>2012-03-24</Created>				</Date>				<Date>					<Modified>2012-03-23</Modified>					 +SIRI v2.0					  Add error number to Error structure				</Date>				<Description>					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common request processing elements</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utility/}siri_permissions-v2.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>				<Relation>					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_types-v2.0.xsd</Requires>					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_utility-v2.0.xsd</Requires>					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_uility/siri_participant-v2.0.xsd</Requires>				</Relation>				<Rights>Unclassified        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the VDV, RTIGXML and Trident standards.</li>					</ul>				</Source>				<Status>Version 2.0 Draft</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,Rail transport, Roads and road transport</Category>				<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>SIRI XML schema. Common Permission model subschema. </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SIRI Framework Permission Types.</xsd:documentation>	</xsd:annotation>	<xsd:include schemaLocation="siri_types-v2.0.xsd"/>	<xsd:include schemaLocation="siri_utility-v1.1.xsd"/>	<xsd:include schemaLocation="siri_participant-v2.0.xsd"/>	<!-- ======================================================================= -->	<!-- ====Permissions================================================= -->	<xsd:complexType name="AbstractTopicPermissionStructure">		<xsd:annotation>			<xsd:documentation>Type for Abstract Permission Topic.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Allow" type="xsd:boolean" default="true">				<xsd:annotation>					<xsd:documentation>Whether the participant may access this topic. Default is 'true'.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<xsd:element name="AllowAll" type="xsd:boolean">		<xsd:annotation>			<xsd:documentation>Allow access to all topics known to the service.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="CapabilityAccessControlStructure">		<xsd:annotation>			<xsd:documentation>Type for Common Access control capabilities.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="RequestChecking" type="xsd:boolean" default="false">				<xsd:annotation>					<xsd:documentation>Whether access control of requests is supported. Default is 'false'.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:complexType name="AbstractPermissionStructure">		<xsd:annotation>			<xsd:documentation>Type for Abstract Permission.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:choice>				<xsd:element name="AllParticipants" type="EmptyType">					<xsd:annotation>						<xsd:documentation>Parmissions apply by default to All particpants. May be overidden by other separate permissions for individual.</xsd:documentation>					</xsd:annotation>				</xsd:element>				<xsd:element name="ParticipantRef" type="ParticipantRefStructure">					<xsd:annotation>						<xsd:documentation>Permission applies to specified participant.</xsd:documentation>					</xsd:annotation>				</xsd:element>			</xsd:choice>			<xsd:element name="GeneralCapabilities" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Permissions for general capabilities.</xsd:documentation>				</xsd:annotation>				<xsd:complexType>					<xsd:sequence>						<xsd:element name="RequestResponse" type="xsd:boolean" default="true">							<xsd:annotation>								<xsd:documentation>Participant may make direct requests for data. Default is 'true'.</xsd:documentation>							</xsd:annotation>						</xsd:element>						<xsd:element name="PublishSubscribe" type="xsd:boolean" default="true">							<xsd:annotation>								<xsd:documentation>Participant may create subscriptions. Default True.</xsd:documentation>							</xsd:annotation>						</xsd:element>					</xsd:sequence>				</xsd:complexType>			</xsd:element>		</xsd:sequence>	</xsd:complexType>	<!-- ====Discovery================================================ --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" id="siri_permissions">
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>CEN TC278 WG3 SG9 Team.</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 2.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>
+				<Date>
+					<Created>2012-03-24</Created>
+				</Date>
+				<Date>
+					<Modified>2012-03-23</Modified>
+					 +SIRI v2.0
+					  Add error number to Error structure
+				</Date>
+				<Description>
+					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common request processing elements</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utility/}siri_permissions-v2.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>
+				<Relation>
+					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_types-v2.0.xsd</Requires>
+					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_utility-v2.0.xsd</Requires>
+					<Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_uility/siri_participant-v2.0.xsd</Requires>
+				</Relation>
+				<Rights>Unclassified
+
+        <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the VDV, RTIGXML and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 2.0 Draft</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,
+Rail transport, Roads and road transport
+</Category>
+				<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>SIRI XML schema. Common Permission model subschema. </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SIRI Framework Permission Types.</xsd:documentation>
+	</xsd:annotation>
+	<xsd:include schemaLocation="siri_types-v2.0.xsd"/>
+	<xsd:include schemaLocation="siri_utility-v1.1.xsd"/>
+	<xsd:include schemaLocation="siri_participant-v2.0.xsd"/>
+	<!-- ======================================================================= -->
+	<!-- ====Permissions================================================= -->
+	<xsd:complexType name="AbstractTopicPermissionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Abstract Permission Topic.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Allow" type="xsd:boolean" default="true">
+				<xsd:annotation>
+					<xsd:documentation>Whether the participant may access this topic. Default is 'true'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="AllowAll" type="xsd:boolean">
+		<xsd:annotation>
+			<xsd:documentation>Allow access to all topics known to the service.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="CapabilityAccessControlStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Common Access control capabilities.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="RequestChecking" type="xsd:boolean" default="false">
+				<xsd:annotation>
+					<xsd:documentation>Whether access control of requests is supported. Default is 'false'.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="AbstractPermissionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Abstract Permission.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:element name="AllParticipants" type="EmptyType">
+					<xsd:annotation>
+						<xsd:documentation>Parmissions apply by default to All particpants. May be overidden by other separate permissions for individual.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="ParticipantRef" type="ParticipantRefStructure">
+					<xsd:annotation>
+						<xsd:documentation>Permission applies to specified participant.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
+			<xsd:element name="GeneralCapabilities" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Permissions for general capabilities.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="RequestResponse" type="xsd:boolean" default="true">
+							<xsd:annotation>
+								<xsd:documentation>Participant may make direct requests for data. Default is 'true'.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="PublishSubscribe" type="xsd:boolean" default="true">
+							<xsd:annotation>
+								<xsd:documentation>Participant may create subscriptions. Default True.</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- ====Discovery================================================ -->
+</xsd:schema>

--- a/schema/1.03/xsd/siri_utility/siri_types-v2.0.xsd
+++ b/schema/1.03/xsd/siri_utility/siri_types-v2.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.siri.org.uk/siri" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_types">
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../xml/xml.xsd"/>
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../wsdl/xml/xml.xsd"/>
 	<xsd:annotation>
 		<xsd:appinfo>
 			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">

--- a/schema/1.03/xsd/siri_utility/siri_types-v2.0.xsd
+++ b/schema/1.03/xsd/siri_utility/siri_types-v2.0.xsd
@@ -1,1 +1,139 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.siri.org.uk/siri" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_types">	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../xml/xml.xsd"/>	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>				<Date>					<Created>2005-10-03</Created>				</Date>				<Date>					<Modified>2005-10-04</Modified>				</Date>				<Date>					<Modified>2005-05-11</Modified>				</Date>				<Date>					<Modified>2007-04-17</Modified>				</Date>				<Date>					<Modified>2012-03-23</Modified>					 +SIRI v2.0					  ADrop unused IP address type 				</Date>				<Description>					<p>SIRI is a European CEN standard for the exchange of real-time information .</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utility/}siri_types-v2.0.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>				<Rights>Unclassified      <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the VDV, RTIG CML and Trident standards.</li>					</ul>				</Source>				<Status>Version 2.0 Draft</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport, Air transport, Airports, Ports and maritime transport, Ferries (marine), Public transport, Bus services, Coach services, Bus stops and stations, Rail transport, Railway stations and track, Train services, Underground trains, Business and industry, Transport, Air transport, Ports and maritime transport, Public transport, Rail transport, Roads and road transport </Category>				<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>SIRI XML schema. Service Interface for Real-time  Information relating to Public Transport Operations. Subschema of time types.</Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SIRI Framework Base Types.</xsd:documentation>	</xsd:annotation>	<!--==== Basic Types =======================================================================-->	<xsd:simpleType name="VersionString">		<xsd:annotation>			<xsd:documentation>A string indicating the versioin of a SIRI data structure.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN"/>	</xsd:simpleType>	<xsd:simpleType name="PopulatedStringType">		<xsd:annotation>			<xsd:documentation>A restriction of W3C XML Schema's string that requires at least one character of text.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:string">			<xsd:minLength value="1"/>		</xsd:restriction>	</xsd:simpleType>	<xsd:complexType name="NaturalLanguageStringStructure">		<xsd:annotation>			<xsd:documentation>Tyoe for a string in a specified language.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="PopulatedStringType">				<xsd:attribute ref="xml:lang" use="optional"/>			</xsd:extension>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="PopulatedPlaceNameType">		<xsd:annotation>			<xsd:documentation>A name that requires at least one character of text and forbids certain reserved characters.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="PopulatedStringType">			<xsd:pattern value="[^,\[\]\{\}\?$%\^=@#;:]+"/>		</xsd:restriction>	</xsd:simpleType>	<xsd:complexType name="NaturalLanguagePlaceNameStructure">		<xsd:annotation>			<xsd:documentation>@lang. ISO language code (default is 'en')A string containing a phrase in a natural language name that requires at least one character of text and forbids certain reserved characters.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:extension base="PopulatedPlaceNameType">				<xsd:attribute ref="xml:lang" use="optional"/>			</xsd:extension>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="IdType">		<xsd:annotation>			<xsd:documentation>Id type for document references.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN"/>	</xsd:simpleType>	<xsd:simpleType name="DurationType">		<xsd:annotation>			<xsd:documentation>Limited version of duration that allows for precise time arithmetic. Only Month, Day, Hour, Minute Second terms should be used. Milliseconds should not be used. Year should not be used. Negative values allowed. e.g. PT1004199059S", "PT130S", "PT2M10S", "P1DT2S", "-P1DT2S".</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:duration"/>	</xsd:simpleType>	<xsd:simpleType name="PositiveDurationType">		<xsd:annotation>			<xsd:documentation>Limited version of duration. Must be positive.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="DurationType"/>	</xsd:simpleType>	<xsd:simpleType name="PhoneType">		<xsd:annotation>			<xsd:documentation>International phonenumber +41675601 etc.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:string"/>	</xsd:simpleType>	<xsd:simpleType name="EmailAddressType">		<xsd:annotation>			<xsd:documentation>Email address type.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:string"/>	</xsd:simpleType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.siri.org.uk/siri" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_types">
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../xml/xml.xsd"/>
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>
+				<Date>
+					<Created>2005-10-03</Created>
+				</Date>
+				<Date>
+					<Modified>2005-10-04</Modified>
+				</Date>
+				<Date>
+					<Modified>2005-05-11</Modified>
+				</Date>
+				<Date>
+					<Modified>2007-04-17</Modified>
+				</Date>
+				<Date>
+					<Modified>2012-03-23</Modified>
+					 +SIRI v2.0
+					  ADrop unused IP address type 
+				</Date>
+				<Description>
+					<p>SIRI is a European CEN standard for the exchange of real-time information .</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utility/}siri_types-v2.0.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>
+				<Rights>Unclassified
+      <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the VDV, RTIG CML and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 2.0 Draft</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+ Air transport, Airports,
+ Ports and maritime transport, Ferries (marine),
+ Public transport, Bus services, Coach services, Bus stops and stations,
+ Rail transport, Railway stations and track, Train services, Underground trains,
+ Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,
+ Rail transport, Roads and road transport
+ </Category>
+				<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>SIRI XML schema. Service Interface for Real-time  Information relating to Public Transport Operations. Subschema of time types.</Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SIRI Framework Base Types.</xsd:documentation>
+	</xsd:annotation>
+	<!--==== Basic Types =======================================================================-->
+	<xsd:simpleType name="VersionString">
+		<xsd:annotation>
+			<xsd:documentation>A string indicating the versioin of a SIRI data structure.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="PopulatedStringType">
+		<xsd:annotation>
+			<xsd:documentation>A restriction of W3C XML Schema's string that requires at least one character of text.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:minLength value="1"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="NaturalLanguageStringStructure">
+		<xsd:annotation>
+			<xsd:documentation>Tyoe for a string in a specified language.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="PopulatedStringType">
+				<xsd:attribute ref="xml:lang" use="optional"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="PopulatedPlaceNameType">
+		<xsd:annotation>
+			<xsd:documentation>A name that requires at least one character of text and forbids certain reserved characters.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="PopulatedStringType">
+			<xsd:pattern value="[^,\[\]\{\}\?$%\^=@#;:]+"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="NaturalLanguagePlaceNameStructure">
+		<xsd:annotation>
+			<xsd:documentation>@lang. ISO language code (default is 'en')
+A string containing a phrase in a natural language name that requires at least one character of text and forbids certain reserved characters.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="PopulatedPlaceNameType">
+				<xsd:attribute ref="xml:lang" use="optional"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="IdType">
+		<xsd:annotation>
+			<xsd:documentation>Id type for document references.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="DurationType">
+		<xsd:annotation>
+			<xsd:documentation>Limited version of duration that allows for precise time arithmetic. Only Month, Day, Hour, Minute Second terms should be used. Milliseconds should not be used. Year should not be used. Negative values allowed. e.g. PT1004199059S", "PT130S", "PT2M10S", "P1DT2S", "-P1DT2S".</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:duration"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="PositiveDurationType">
+		<xsd:annotation>
+			<xsd:documentation>Limited version of duration. Must be positive.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="DurationType"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="PhoneType">
+		<xsd:annotation>
+			<xsd:documentation>International phonenumber +41675601 etc.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="EmailAddressType">
+		<xsd:annotation>
+			<xsd:documentation>Email address type.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string"/>
+	</xsd:simpleType>
+</xsd:schema>

--- a/schema/1.03/xsd/siri_utility/siri_utility-v1.1.xsd
+++ b/schema/1.03/xsd/siri_utility/siri_utility-v1.1.xsd
@@ -1,1 +1,83 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_utility">	<!-- ======================================================================= -->	<xsd:annotation>		<xsd:appinfo>			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">				<Aggregation>main schema</Aggregation>				<Audience>e-service developers</Audience>				<Contributor>CEN TC278 WG3 SG9 Team.</Contributor>				<Coverage>Europe</Coverage>				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>				<Date>					<Created>2008-09-307</Created>					  change any to lax / emopty  				</Date>				<Date>					<Created>2007-04-17</Created>				</Date>				<Description>					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common utility types</p>				</Description>				<Format>					<MediaType>text/xml</MediaType>					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>					<Description>XML schema, W3C Recommendation 2001</Description>				</Format>				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utiliyty/}siri_utility-v1.1.xsd</Identifier>				<Language>[ISO 639-2/B] ENG</Language>				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>				<Rights>Unclassified       <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>				</Rights>				<Source>					<ul>						<li>Derived from the VDV, RTIGXML and Trident standards.</li>					</ul>				</Source>				<Status>Version 2.0 Draft</Status>				<Subject>					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,Air transport, Airports,Ports and maritime transport, Ferries (marine),Public transport, Bus services, Coach services, Bus stops and stations,Rail transport, Railway stations and track, Train services, Underground trains,Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,Rail transport, Roads and road transport</Category>				<Project>CEN TC278 WG3 SG9.</Project>				</Subject>				<Title>SIRI XML schema. Shared utility types </Title>				<Type>Standard</Type>			</Metadata>		</xsd:appinfo>		<xsd:documentation>SIRI Framework Utility Types.</xsd:documentation>	</xsd:annotation>	<!-- ======================================================================= -->	<xsd:simpleType name="EmptyType">		<xsd:annotation>			<xsd:documentation>A type with no allowed content, used when simply the presence of an element is significant.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:string">			<xsd:enumeration value=""/>		</xsd:restriction>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:element name="Extensions" type="ExtensionsStructure">		<xsd:annotation>			<xsd:documentation>Extensions to schema. (Wrapper tag used to avoid problems with handling of optional 'any' by some validators).</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ExtensionsStructure">		<xsd:annotation>			<xsd:documentation>Type for Extensions to schema. Wraps an 'any' tag to ensure decidability.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:any namespace="##any" processContents="lax" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Placeholder for user extensions.</xsd:documentation>				</xsd:annotation>			</xsd:any>		</xsd:sequence>	</xsd:complexType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_utility">
+	<!-- ======================================================================= -->
+	<xsd:annotation>
+		<xsd:appinfo>
+			<Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
+				<Aggregation>main schema</Aggregation>
+				<Audience>e-service developers</Audience>
+				<Contributor>CEN TC278 WG3 SG9 Team.</Contributor>
+				<Coverage>Europe</Coverage>
+				<Creator>First drafted for version 1.0 CEN TC278 WG3 SG9 Editor Nicholas Knowles.  mailto:schemer@siri.org.uk</Creator>
+				<Date>
+					<Created>2008-09-307</Created>
+					  change any to lax / emopty  
+				</Date>
+				<Date>
+					<Created>2007-04-17</Created>
+				</Date>
+				<Description>
+					<p>SIRI is a European CEN standard for the exchange of real-time information. This subschema defines common utility types</p>
+				</Description>
+				<Format>
+					<MediaType>text/xml</MediaType>
+					<Syntax>http://www.w3.org/2001/XMLSchema</Syntax>
+					<Description>XML schema, W3C Recommendation 2001</Description>
+				</Format>
+				<Identifier>{http://www.siri.org.uk/schema/2.0/xsd/siri_utiliyty/}siri_utility-v1.1.xsd</Identifier>
+				<Language>[ISO 639-2/B] ENG</Language>
+				<Publisher>Kizoom, 109-123 Clifton Street, London EC4A 4LD </Publisher>
+				<Rights>Unclassified
+       <Copyright>CEN, VDV, RTIG 2004-2012</Copyright>
+				</Rights>
+				<Source>
+					<ul>
+						<li>Derived from the VDV, RTIGXML and Trident standards.</li>
+					</ul>
+				</Source>
+				<Status>Version 2.0 Draft</Status>
+				<Subject>
+					<Category>Arts, recreation and travel, Tourism, Travel (tourism), Transport,
+Air transport, Airports,
+Ports and maritime transport, Ferries (marine),
+Public transport, Bus services, Coach services, Bus stops and stations,
+Rail transport, Railway stations and track, Train services, Underground trains,
+Business and industry, Transport, Air transport, Ports and maritime transport, Public transport,
+Rail transport, Roads and road transport
+</Category>
+				<Project>CEN TC278 WG3 SG9.</Project>
+				</Subject>
+				<Title>SIRI XML schema. Shared utility types </Title>
+				<Type>Standard</Type>
+			</Metadata>
+		</xsd:appinfo>
+		<xsd:documentation>SIRI Framework Utility Types.</xsd:documentation>
+	</xsd:annotation>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="EmptyType">
+		<xsd:annotation>
+			<xsd:documentation>A type with no allowed content, used when simply the presence of an element is significant.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value=""/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:element name="Extensions" type="ExtensionsStructure">
+		<xsd:annotation>
+			<xsd:documentation>Extensions to schema. (Wrapper tag used to avoid problems with handling of optional 'any' by some validators).</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ExtensionsStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for Extensions to schema. Wraps an 'any' tag to ensure decidability.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:any namespace="##any" processContents="lax" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Placeholder for user extensions.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:any>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/schema/1.03/xsd/wsdl/NeTEx_wsConsumer-Document.wsdl
+++ b/schema/1.03/xsd/wsdl/NeTEx_wsConsumer-Document.wsdl
@@ -1,1 +1,66 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2011 rel. 2 sp1 (x64) (http://www.altova.com) by Christophe Duquesne (Aurige) --><definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:netexWs="http://www.siri.org.uk/siriWS" xmlns:netex="http://www.netex.org.uk/netex" xmlns:ns="http://www.opengis.net/gml/3.2" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.siri.org.uk/siriWS">	<types>		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" xmlns:netexWs="http://www.siri.org.uk/siriWS" targetNamespace="http://www.siri.org.uk/siriWS">			<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../netex_siri.xsd"/>			<xsd:element name="NotifyNetex">				<xsd:complexType>					<xsd:sequence>						<xsd:element name="Request" type="siri:SiriResponseStructure"/>					</xsd:sequence>				</xsd:complexType>			</xsd:element>		</xsd:schema>		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" xmlns:netexWs="http://www.siri.org.uk/siriWS" targetNamespace="http://www.siri.org.uk/siriWS">			<xsd:include schemaLocation="../wsdl_model/siri_wsConsumer-Framework.xsd"/>		</xsd:schema>	</types>	<message name="HeartbeatNotify">		<part name="HeartbeatNotifyParameters" element="netexWs:NotifyHeartbeat"/>	</message>	<message name="DataReadyNotify">		<part name="DataReadyNotifyParameters" element="netexWs:NotifyDataReady"/>	</message>	<message name="NetexNotify">		<part name="Notification" type="siri:SiriResponseStructure"/>	</message>	<portType name="NetexConsumerDocPort">		<operation name="NotifyDataReady">			<input message="netexWs:DataReadyNotify"/>		</operation>		<operation name="NotifyHeartbeat">			<input message="netexWs:HeartbeatNotify"/>		</operation>		<!-- == Service Specific == -->		<operation name="NotifyNetex">			<input message="netexWs:NetexNotify"/>		</operation>	</portType>	<binding name="NetexConsumerDocBinding" type="netexWs:NetexConsumerDocPort">		<soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>		<operation name="NotifyDataReady">			<soap:operation soapAction="NotifyDataReady"/>			<input>				<soap:body use="literal" namespace="http://wsdl.siri.org.uk/siri"/>			</input>		</operation>		<operation name="NotifyHeartbeat">			<soap:operation soapAction="NotifyHeartbeat"/>			<input>				<soap:body use="literal" namespace="http://wsdl.siri.org.uk/siri"/>			</input>		</operation>		<operation name="NotifyNetex">			<soap:operation soapAction="GetNetex"/>			<input>				<soap:body use="literal" namespace="http://wsdl.siri.org.uk/siri"/>			</input>		</operation>	</binding>	<service name="NetexConsumerDocServices">		<port name="NetexiWSPort" binding="netexWs:NetexConsumerDocBinding">			<soap:address location="http://www.netex-service-location.com"/>		</port>	</service></definitions>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2011 rel. 2 sp1 (x64) (http://www.altova.com) by Christophe Duquesne (Aurige) -->
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:netexWs="http://www.siri.org.uk/siriWS" xmlns:netex="http://www.netex.org.uk/netex" xmlns:ns="http://www.opengis.net/gml/3.2" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.siri.org.uk/siriWS">
+	<types>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" xmlns:netexWs="http://www.siri.org.uk/siriWS" targetNamespace="http://www.siri.org.uk/siriWS">
+			<xsd:import namespace="http://www.siri.org.uk/siri" schemaLocation="../netex_siri.xsd"/>
+			<xsd:element name="NotifyNetex">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element name="Request" type="siri:SiriResponseStructure"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:schema>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:siri="http://www.siri.org.uk/siri" xmlns:netexWs="http://www.siri.org.uk/siriWS" targetNamespace="http://www.siri.org.uk/siriWS">
+			<xsd:include schemaLocation="../wsdl_model/siri_wsConsumer-Framework.xsd"/>
+		</xsd:schema>
+	</types>
+	<message name="HeartbeatNotify">
+		<part name="HeartbeatNotifyParameters" element="netexWs:NotifyHeartbeat"/>
+	</message>
+	<message name="DataReadyNotify">
+		<part name="DataReadyNotifyParameters" element="netexWs:NotifyDataReady"/>
+	</message>
+	<message name="NetexNotify">
+		<part name="Notification" type="siri:SiriResponseStructure"/>
+	</message>
+	<portType name="NetexConsumerDocPort">
+		<operation name="NotifyDataReady">
+			<input message="netexWs:DataReadyNotify"/>
+		</operation>
+		<operation name="NotifyHeartbeat">
+			<input message="netexWs:HeartbeatNotify"/>
+		</operation>
+		<!-- == Service Specific == -->
+		<operation name="NotifyNetex">
+			<input message="netexWs:NetexNotify"/>
+		</operation>
+	</portType>
+	<binding name="NetexConsumerDocBinding" type="netexWs:NetexConsumerDocPort">
+		<soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+		<operation name="NotifyDataReady">
+			<soap:operation soapAction="NotifyDataReady"/>
+			<input>
+				<soap:body use="literal" namespace="http://wsdl.siri.org.uk/siri"/>
+			</input>
+		</operation>
+		<operation name="NotifyHeartbeat">
+			<soap:operation soapAction="NotifyHeartbeat"/>
+			<input>
+				<soap:body use="literal" namespace="http://wsdl.siri.org.uk/siri"/>
+			</input>
+		</operation>
+		<operation name="NotifyNetex">
+			<soap:operation soapAction="GetNetex"/>
+			<input>
+				<soap:body use="literal" namespace="http://wsdl.siri.org.uk/siri"/>
+			</input>
+		</operation>
+	</binding>
+	<service name="NetexConsumerDocServices">
+		<port name="NetexiWSPort" binding="netexWs:NetexConsumerDocBinding">
+			<soap:address location="http://www.netex-service-location.com"/>
+		</port>
+	</service>
+</definitions>

--- a/schema/1.03/xsd/wsdl/NeTEx_wsConsumer-Rpc.wsdl
+++ b/schema/1.03/xsd/wsdl/NeTEx_wsConsumer-Rpc.wsdl
@@ -1,1 +1,60 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- edited with XMLSpy v2011 rel. 2 sp1 (x64) (http://www.altova.com) by Christophe Duquesne (Aurige) --><definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:netexWs="http://www.siri.org.uk/siriWS" xmlns:netex="http://www.netex.org.uk/netex" xmlns:ns="http://www.opengis.net/gml/3.2" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.siri.org.uk/siriWS">	<types>		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri">			<xsd:include schemaLocation="../netex_siri.xsd"/>		</xsd:schema>	</types>	<message name="HeartbeatNotify">		<part name="HeartbeatNotifyInfo" type="siri:ProducerRequestEndpointStructure"/>		<part name="Notification" type="siri:CheckStatusResponseBodyStructure"/>		<part name="SiriExtension" type="siri:ExtensionsStructure"/>	</message>	<message name="DataReadyNotify">		<part name="Notification" type="siri:DataReadyRequestStructure"/>		<part name="SiriExtension" type="siri:ExtensionsStructure"/>	</message>	<message name="NetexNotify">		<part name="Notification" type="siri:SiriResponseStructure"/>	</message>	<portType name="NetexConsumerRpcPort">		<documentation>Defines all the netex SOAP notifications</documentation>		<operation name="NotifyDataReady">			<input message="netexWs:DataReadyNotify"/>		</operation>		<operation name="NotifyHeartbeat">			<input message="netexWs:HeartbeatNotify"/>		</operation>		<!-- == Service Specific == -->		<operation name="NotifyNetex">			<input message="netexWs:NetexNotify"/>		</operation>	</portType>	<binding name="NetexConsumerRpcBinding" type="netexWs:NetexConsumerRpcPort">		<soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>		<operation name="NotifyDataReady">			<soap:operation soapAction="NotifyDataReady"/>			<input>				<soap:body use="literal" namespace="http://www.siri.org.uk/siriWS"/>			</input>		</operation>		<operation name="NotifyHeartbeat">			<soap:operation soapAction="NotifyHeartbeat"/>			<input>				<soap:body use="literal" namespace="http://www.siri.org.uk/siriWS"/>			</input>		</operation>		<operation name="NotifyNetex">			<soap:operation soapAction="GetNetex"/>			<input>				<soap:body use="literal" namespace="http://www.siri.org.uk/siriWS"/>			</input>		</operation>	</binding>	<service name="NetexConsumerRpcServices">		<port name="NetexWSPort" binding="netexWs:NetexConsumerRpcBinding">			<soap:address location="http://www.netex-service-location.com"/>		</port>	</service></definitions>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2011 rel. 2 sp1 (x64) (http://www.altova.com) by Christophe Duquesne (Aurige) -->
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:netexWs="http://www.siri.org.uk/siriWS" xmlns:netex="http://www.netex.org.uk/netex" xmlns:ns="http://www.opengis.net/gml/3.2" xmlns:siri="http://www.siri.org.uk/siri" targetNamespace="http://www.siri.org.uk/siriWS">
+	<types>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri">
+			<xsd:include schemaLocation="../netex_siri.xsd"/>
+		</xsd:schema>
+	</types>
+	<message name="HeartbeatNotify">
+		<part name="HeartbeatNotifyInfo" type="siri:ProducerRequestEndpointStructure"/>
+		<part name="Notification" type="siri:CheckStatusResponseBodyStructure"/>
+		<part name="SiriExtension" type="siri:ExtensionsStructure"/>
+	</message>
+	<message name="DataReadyNotify">
+		<part name="Notification" type="siri:DataReadyRequestStructure"/>
+		<part name="SiriExtension" type="siri:ExtensionsStructure"/>
+	</message>
+	<message name="NetexNotify">
+		<part name="Notification" type="siri:SiriResponseStructure"/>
+	</message>
+	<portType name="NetexConsumerRpcPort">
+		<documentation>Defines all the netex SOAP notifications</documentation>
+		<operation name="NotifyDataReady">
+			<input message="netexWs:DataReadyNotify"/>
+		</operation>
+		<operation name="NotifyHeartbeat">
+			<input message="netexWs:HeartbeatNotify"/>
+		</operation>
+		<!-- == Service Specific == -->
+		<operation name="NotifyNetex">
+			<input message="netexWs:NetexNotify"/>
+		</operation>
+	</portType>
+	<binding name="NetexConsumerRpcBinding" type="netexWs:NetexConsumerRpcPort">
+		<soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<operation name="NotifyDataReady">
+			<soap:operation soapAction="NotifyDataReady"/>
+			<input>
+				<soap:body use="literal" namespace="http://www.siri.org.uk/siriWS"/>
+			</input>
+		</operation>
+		<operation name="NotifyHeartbeat">
+			<soap:operation soapAction="NotifyHeartbeat"/>
+			<input>
+				<soap:body use="literal" namespace="http://www.siri.org.uk/siriWS"/>
+			</input>
+		</operation>
+		<operation name="NotifyNetex">
+			<soap:operation soapAction="GetNetex"/>
+			<input>
+				<soap:body use="literal" namespace="http://www.siri.org.uk/siriWS"/>
+			</input>
+		</operation>
+	</binding>
+	<service name="NetexConsumerRpcServices">
+		<port name="NetexWSPort" binding="netexWs:NetexConsumerRpcBinding">
+			<soap:address location="http://www.netex-service-location.com"/>
+		</port>
+	</service>
+</definitions>

--- a/schema/1.03/xsd/ynotation/netex_subThing_support-v0.1.xsd
+++ b/schema/1.03/xsd/ynotation/netex_subThing_support-v0.1.xsd
@@ -1,1 +1,212 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1" id="netex_Thing">	<xsd:include schemaLocation="../netex_framework/netex_responsibility/netex_responsibility_version-v0.4.xsd"/>	<!-- ======================================================================= -->	<xsd:element name="AncestorARef" type="AncestorARefStructure" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation>Reference to a ANCESTOR A.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AncestorARefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a ANCESTOR A.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="AncestorAIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced ANCESTOR A</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="AncestorAIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of ANCESTOR A</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:element name="AncestorBRef" type="AncestorBRefStructure" substitutionGroup="AncestorARef">		<xsd:annotation>			<xsd:documentation>Reference to a ANCESTOR B.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="AncestorBRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a ANCESTOR B.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="AncestorARefStructure">				<xsd:attribute name="ref" type="AncestorBIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced ANCESTOR B</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="AncestorBIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of ANCESTOR B</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="AncestorAIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:element name="SubARef" type="SubARefStructure" substitutionGroup="AncestorARef">		<xsd:annotation>			<xsd:documentation>Reference to a SUB A.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="SubARefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SUB A.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="AncestorARefStructure">				<xsd:attribute name="ref" type="SubAIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced SUB A</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="SubAIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of SUB A</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="AncestorAIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:element name="SubSubARef" type="SubSubARefStructure" substitutionGroup="AncestorARef">		<xsd:annotation>			<xsd:documentation>Reference to a SUB SUB A.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="SubSubARefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SUB SUB A.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="SubARefStructure">				<xsd:attribute name="ref" type="SubSubAIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced SUB SUB A</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="SubSubAIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of SUB SUB A</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="SubAIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:element name="SubABRef" type="SubABRefStructure" substitutionGroup="AncestorBRef">		<xsd:annotation>			<xsd:documentation>Reference to a SUB AB.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="SubABRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SUB AB.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="AncestorBRefStructure">				<xsd:attribute name="ref" type="SubABIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced SUB AB</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="SubABIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of SUB AB</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="AncestorBIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:element name="SubACRef" type="SubACRefStructure" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation>Reference to a SUB AC.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="SubACRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SUB AC.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="AncestorARefStructure">				<xsd:attribute name="ref" type="SubACIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced SUB AC</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="SubACIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of SUB AC</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="AncestorAIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:element name="SubABCRef" type="SubABCRefStructure" substitutionGroup="AncestorBRef">		<xsd:annotation>			<xsd:documentation>Reference to a SUB ABC.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="SubABCRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SUB ABC.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="AncestorBRefStructure">				<xsd:attribute name="ref" type="SubABCIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced SUB ABC</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="SubABCIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of SUB ABC</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="AncestorBIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:element name="SubSubABCRef" type="SubSubABCRefStructure" substitutionGroup="SubABCRef">		<xsd:annotation>			<xsd:documentation>Reference to a SUB SUB ABC.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="SubSubABCRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SUB SUB ABC.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="SubABCRefStructure">				<xsd:attribute name="ref" type="SubSubABCIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced SUB SUB ABC</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="SubSubABCIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of SUB SUB ABC</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="SubABCIdType"/>	</xsd:simpleType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1" id="netex_Thing">
+	<xsd:include schemaLocation="../netex_framework/netex_responsibility/netex_responsibility_version-v0.4.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:element name="AncestorARef" type="AncestorARefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a ANCESTOR A.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AncestorARefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a ANCESTOR A.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="AncestorAIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced ANCESTOR A</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="AncestorAIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of ANCESTOR A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:element name="AncestorBRef" type="AncestorBRefStructure" substitutionGroup="AncestorARef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a ANCESTOR B.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="AncestorBRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a ANCESTOR B.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AncestorARefStructure">
+				<xsd:attribute name="ref" type="AncestorBIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced ANCESTOR B</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="AncestorBIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of ANCESTOR B</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AncestorAIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:element name="SubARef" type="SubARefStructure" substitutionGroup="AncestorARef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SUB A.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SubARefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SUB A.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AncestorARefStructure">
+				<xsd:attribute name="ref" type="SubAIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced SUB A</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SubAIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of SUB A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AncestorAIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:element name="SubSubARef" type="SubSubARefStructure" substitutionGroup="AncestorARef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SUB SUB A.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SubSubARefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SUB SUB A.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="SubARefStructure">
+				<xsd:attribute name="ref" type="SubSubAIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced SUB SUB A</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SubSubAIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of SUB SUB A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="SubAIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:element name="SubABRef" type="SubABRefStructure" substitutionGroup="AncestorBRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SUB AB.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SubABRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SUB AB.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AncestorBRefStructure">
+				<xsd:attribute name="ref" type="SubABIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced SUB AB</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SubABIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of SUB AB</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AncestorBIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:element name="SubACRef" type="SubACRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SUB AC.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SubACRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SUB AC.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AncestorARefStructure">
+				<xsd:attribute name="ref" type="SubACIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced SUB AC</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SubACIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of SUB AC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AncestorAIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:element name="SubABCRef" type="SubABCRefStructure" substitutionGroup="AncestorBRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SUB ABC.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SubABCRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SUB ABC.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="AncestorBRefStructure">
+				<xsd:attribute name="ref" type="SubABCIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced SUB ABC</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SubABCIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of SUB ABC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="AncestorBIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:element name="SubSubABCRef" type="SubSubABCRefStructure" substitutionGroup="SubABCRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SUB SUB ABC.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SubSubABCRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SUB SUB ABC.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="SubABCRefStructure">
+				<xsd:attribute name="ref" type="SubSubABCIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced SUB SUB ABC</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SubSubABCIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of SUB SUB ABC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="SubABCIdType"/>
+	</xsd:simpleType>
+</xsd:schema>

--- a/schema/1.03/xsd/ynotation/netex_subThing_version-v0.1.xsd
+++ b/schema/1.03/xsd/ynotation/netex_subThing_version-v0.1.xsd
@@ -1,1 +1,451 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1" id="netex_subThing">	<xsd:include schemaLocation="netex_thing_support-v0.1.xsd"/>	<xsd:include schemaLocation="netex_subThing_support-v0.1.xsd"/>	<!-- === NOTATION EXAMPLE E==== =================================================== -->	<!-- ======================================================================= -->	<!-- ==== ANCESTOR A ========================================================= -->	<xsd:element name="AncestorA" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A ANCESTOR A</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="AncestorA_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorAGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="AncestorAIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of THING</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="AncestorA_VersionStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for an ANCESTOR A</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="DataManagedObjectStructure">				<xsd:sequence>					<xsd:group ref="AncestorAGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="AncestorAGroup">		<xsd:annotation>			<xsd:documentation>Elements for a ANCESTOR A</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="AncestorAProperty" type="xsd:string" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Name of ANCESTOR A</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element ref="ThingRef" minOccurs="0"/>		</xsd:sequence>	</xsd:group>	<!-- ==== ANCESTOR B ========================================================= -->	<xsd:element name="AncestorB" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A ANCESTOR B</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="AncestorB_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorAGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorBGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="AncestorBIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of THING</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="AncestorB_VersionStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for an ANCESTOR B</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AncestorA_VersionStructure">				<xsd:sequence>					<xsd:group ref="AncestorBGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="AncestorBGroup">		<xsd:annotation>			<xsd:documentation>Elements for a ANCESTOR B</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="AncestorBProperty" type="xsd:integer">				<xsd:annotation>					<xsd:documentation>Property of ANCESTOR A</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ===== SomethingElse =============================================== -->	<xsd:group name="AncestorCGroup">		<xsd:annotation>			<xsd:documentation>Elements for a ANCESTOR  C.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="AncestorCProperty" type="xsd:anyURI" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Property for ANCESTOR C</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ==== SUB A ========================================================= -->	<xsd:element name="SubA" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A SUB A</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="SubA_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorAGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="SubAGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="SubAIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of THING</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="SubA_VersionStructure">		<xsd:annotation>			<xsd:documentation>Type for an SUB A</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AncestorA_VersionStructure">				<xsd:sequence>					<xsd:group ref="SubAGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="SubAGroup">		<xsd:annotation>			<xsd:documentation>Elements for a SUB A</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="SubAProperty" type="xsd:normalizedString">				<xsd:annotation>					<xsd:documentation>Property of SUB AA</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ==== SUB SUB A ========================================================= -->	<xsd:element name="SubSubA" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A SUB SUB A</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="SubSubA_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorAGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="SubAGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:element name="SubSubAProperty" type="xsd:normalizedString">								<xsd:annotation>									<xsd:documentation>Property of SUB SUB A</xsd:documentation>								</xsd:annotation>							</xsd:element>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="SubSubAIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of SUB SUB A</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="SubSubA_VersionStructure">		<xsd:annotation>			<xsd:documentation>Type for an SUB SUB A</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="SubA_VersionStructure">				<xsd:group ref="SubSubAGroup"/>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="SubSubAGroup">		<xsd:annotation>			<xsd:documentation>Elements for a SUB SUB A</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="SubSubAProperty" type="xsd:normalizedString">				<xsd:annotation>					<xsd:documentation>Property of SUB SUB A</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ==== SUB AB ========================================================= -->	<xsd:element name="SubAB" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A SUB AB</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="SubAB_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorAGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="SubABGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="SubABIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of THING</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="SubAB_VersionStructure">		<xsd:annotation>			<xsd:documentation>Type for an SUB AB</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AncestorA_VersionStructure">				<xsd:sequence>					<xsd:group ref="SubABGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="SubABGroup">		<xsd:annotation>			<xsd:documentation>Elements for a SUB AB</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="SubABProperty" type="xsd:normalizedString">				<xsd:annotation>					<xsd:documentation>Property of SUB ABA</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ==== SUB ABC ========================================================= -->	<xsd:element name="SubABC" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A SUB ABC</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="SubABC_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorAGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorBGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="SubABCGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="SubABCIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of THING</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="SubABC_VersionStructure">		<xsd:annotation>			<xsd:documentation>Type for an SUB ABC</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AncestorB_VersionStructure">				<xsd:sequence>					<xsd:group ref="SubABCGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="SubABCGroup">		<xsd:annotation>			<xsd:documentation>Elements for a SUB ABC</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:group ref="AncestorCGroup"/>			<xsd:element name="SubABCProperty" type="MultilingualString">				<xsd:annotation>					<xsd:documentation>Property of SUB ABCA</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ==== SUB SUB ABC ========================================================= -->	<xsd:element name="SubSubABC" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A SUB SUB ABC</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="SubSubABC_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorAGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorBGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="SubABCGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="SubSubABCGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="SubSubABCIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of THING</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="SubSubABC_VersionStructure">		<xsd:annotation>			<xsd:documentation>Type for an SUB SUB ABC</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="SubABC_VersionStructure">				<xsd:sequence>					<xsd:group ref="SubSubABCGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="SubSubABCGroup">		<xsd:annotation>			<xsd:documentation>Elements for a SUB SUB ABC</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="SubSubABCProperty" type="MultilingualString">				<xsd:annotation>					<xsd:documentation>Property of SUB SUB ABCA</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ==== SUB AC ========================================================= -->	<xsd:element name="SubAC" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A SUB AC</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="SubAC_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="AncestorAGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="SubACGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="SubACIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of THING</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="SubAC_VersionStructure">		<xsd:annotation>			<xsd:documentation>Type for an SUB AC</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="AncestorA_VersionStructure">				<xsd:sequence>					<xsd:group ref="SubACGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="SubACGroup">		<xsd:annotation>			<xsd:documentation>Elements for a SUB AC</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:group ref="AncestorCGroup"/>			<xsd:element name="SubACProperty" type="xsd:normalizedString">				<xsd:annotation>					<xsd:documentation>Property of SUB AC</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1" id="netex_subThing">
+	<xsd:include schemaLocation="netex_thing_support-v0.1.xsd"/>
+	<xsd:include schemaLocation="netex_subThing_support-v0.1.xsd"/>
+	<!-- === NOTATION EXAMPLE E==== =================================================== -->
+	<!-- ======================================================================= -->
+	<!-- ==== ANCESTOR A ========================================================= -->
+	<xsd:element name="AncestorA" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A ANCESTOR A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="AncestorA_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorAGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="AncestorAIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of THING</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="AncestorA_VersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for an ANCESTOR A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:sequence>
+					<xsd:group ref="AncestorAGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="AncestorAGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a ANCESTOR A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="AncestorAProperty" type="xsd:string" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of ANCESTOR A</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ThingRef" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== ANCESTOR B ========================================================= -->
+	<xsd:element name="AncestorB" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A ANCESTOR B</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="AncestorB_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorAGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorBGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="AncestorBIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of THING</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="AncestorB_VersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for an ANCESTOR B</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AncestorA_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="AncestorBGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="AncestorBGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a ANCESTOR B</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="AncestorBProperty" type="xsd:integer">
+				<xsd:annotation>
+					<xsd:documentation>Property of ANCESTOR A</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ===== SomethingElse =============================================== -->
+	<xsd:group name="AncestorCGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a ANCESTOR  C.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="AncestorCProperty" type="xsd:anyURI" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Property for ANCESTOR C</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== SUB A ========================================================= -->
+	<xsd:element name="SubA" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A SUB A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SubA_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorAGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SubAGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SubAIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of THING</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SubA_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for an SUB A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AncestorA_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SubAGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SubAGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SUB A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SubAProperty" type="xsd:normalizedString">
+				<xsd:annotation>
+					<xsd:documentation>Property of SUB AA</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== SUB SUB A ========================================================= -->
+	<xsd:element name="SubSubA" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A SUB SUB A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SubSubA_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorAGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SubAGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:element name="SubSubAProperty" type="xsd:normalizedString">
+								<xsd:annotation>
+									<xsd:documentation>Property of SUB SUB A</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SubSubAIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of SUB SUB A</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SubSubA_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for an SUB SUB A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="SubA_VersionStructure">
+				<xsd:group ref="SubSubAGroup"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SubSubAGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SUB SUB A</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SubSubAProperty" type="xsd:normalizedString">
+				<xsd:annotation>
+					<xsd:documentation>Property of SUB SUB A</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== SUB AB ========================================================= -->
+	<xsd:element name="SubAB" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A SUB AB</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SubAB_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorAGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SubABGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SubABIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of THING</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SubAB_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for an SUB AB</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AncestorA_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SubABGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SubABGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SUB AB</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SubABProperty" type="xsd:normalizedString">
+				<xsd:annotation>
+					<xsd:documentation>Property of SUB ABA</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== SUB ABC ========================================================= -->
+	<xsd:element name="SubABC" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A SUB ABC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SubABC_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorAGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorBGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SubABCGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SubABCIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of THING</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SubABC_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for an SUB ABC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AncestorB_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SubABCGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SubABCGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SUB ABC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="AncestorCGroup"/>
+			<xsd:element name="SubABCProperty" type="MultilingualString">
+				<xsd:annotation>
+					<xsd:documentation>Property of SUB ABCA</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== SUB SUB ABC ========================================================= -->
+	<xsd:element name="SubSubABC" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A SUB SUB ABC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SubSubABC_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorAGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorBGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SubABCGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SubSubABCGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SubSubABCIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of THING</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SubSubABC_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for an SUB SUB ABC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="SubABC_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SubSubABCGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SubSubABCGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SUB SUB ABC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="SubSubABCProperty" type="MultilingualString">
+				<xsd:annotation>
+					<xsd:documentation>Property of SUB SUB ABCA</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== SUB AC ========================================================= -->
+	<xsd:element name="SubAC" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A SUB AC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SubAC_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="AncestorAGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SubACGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="SubACIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of THING</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SubAC_VersionStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for an SUB AC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="AncestorA_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="SubACGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SubACGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SUB AC</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:group ref="AncestorCGroup"/>
+			<xsd:element name="SubACProperty" type="xsd:normalizedString">
+				<xsd:annotation>
+					<xsd:documentation>Property of SUB AC</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+</xsd:schema>

--- a/schema/1.03/xsd/ynotation/netex_thing_support-v0.1.xsd
+++ b/schema/1.03/xsd/ynotation/netex_thing_support-v0.1.xsd
@@ -1,1 +1,129 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1" id="netex_Thing">	<xsd:include schemaLocation="../netex_framework/netex_responsibility/netex_responsibility_version-v0.4.xsd"/>	<!-- ======================================================================= -->	<xsd:element name="ThingRef" type="ThingRefStructure" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation>Reference to a THING.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ThingRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a THING.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="ThingIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced THING</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<xsd:simpleType name="ThingIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of Thing</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:simpleType name="ChildThingIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of a CHild Thing</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<!-- ======================================================================= -->	<xsd:complexType name="somethingElseRefs_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a list of relalted SOMETHING ELSES</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="oneToManyRelationshipStructure">				<xsd:sequence>					<xsd:element ref="SomethingElseRef" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:simpleType name="SomethingElseIdType">		<xsd:annotation>			<xsd:documentation>Type for an identifier of a SOMETHING ELSE.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="ObjectIdType"/>	</xsd:simpleType>	<xsd:element name="SomethingElseRef" type="SomethingElseRefStructure" substitutionGroup="VersionOfObjectRef">		<xsd:annotation>			<xsd:documentation>Reference to a SOMETHING ELSE.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="SomethingElseRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a SOMETHING ELSE.</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="VersionOfObjectRefStructure">				<xsd:attribute name="ref" type="SomethingElseIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced SOMETHING ELSE.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:complexType name="typeOfThingRefs_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a list of TYPE OF THINGs.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="oneToManyRelationshipStructure">				<xsd:sequence>					<xsd:element ref="TypeOfThingRef" minOccurs="0" maxOccurs="unbounded">						<xsd:annotation>							<xsd:documentation>Refernce to a TYPE OF THING.</xsd:documentation>						</xsd:annotation>					</xsd:element>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:simpleType name="TypeOfThingIdType">		<xsd:annotation>			<xsd:documentation>Type for identifier of a TYPE OF THING.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="TypeOfValueIdType"/>	</xsd:simpleType>	<xsd:element name="TypeOfThingRef" type="TypeOfThingRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">		<xsd:annotation>			<xsd:documentation>Reference to a TYPE OF THING</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="TypeOfThingRefStructure">		<xsd:annotation>			<xsd:documentation>Type for a reference to a TYPE OF THING</xsd:documentation>		</xsd:annotation>		<xsd:simpleContent>			<xsd:restriction base="TypeOfValueRefStructure">				<xsd:attribute name="ref" type="TypeOfThingIdType" use="required">					<xsd:annotation>						<xsd:documentation>Identifier of referenced SOMETHING ELSE.</xsd:documentation>					</xsd:annotation>				</xsd:attribute>			</xsd:restriction>		</xsd:simpleContent>	</xsd:complexType>	<!-- ======================================================================= -->	<xsd:simpleType name="ThingTypeEnumeration">		<xsd:annotation>			<xsd:documentation>Modes of transport applicable to private and non-timetabled transport.</xsd:documentation>		</xsd:annotation>		<xsd:restriction base="xsd:NMTOKEN">			<xsd:enumeration value="nextBig"/>			<xsd:enumeration value="nextSmall"/>			<xsd:enumeration value="soWhat"/>			<xsd:enumeration value="smelly"/>		</xsd:restriction>	</xsd:simpleType></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1" id="netex_Thing">
+	<xsd:include schemaLocation="../netex_framework/netex_responsibility/netex_responsibility_version-v0.4.xsd"/>
+	<!-- ======================================================================= -->
+	<xsd:element name="ThingRef" type="ThingRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a THING.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ThingRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a THING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="ThingIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced THING</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="ThingIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of Thing</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="ChildThingIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of a CHild Thing</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="somethingElseRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of relalted SOMETHING ELSES</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="SomethingElseRef" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="SomethingElseIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for an identifier of a SOMETHING ELSE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="SomethingElseRef" type="SomethingElseRefStructure" substitutionGroup="VersionOfObjectRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a SOMETHING ELSE.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="SomethingElseRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a SOMETHING ELSE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="VersionOfObjectRefStructure">
+				<xsd:attribute name="ref" type="SomethingElseIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced SOMETHING ELSE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:complexType name="typeOfThingRefs_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of TYPE OF THINGs.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="oneToManyRelationshipStructure">
+				<xsd:sequence>
+					<xsd:element ref="TypeOfThingRef" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Refernce to a TYPE OF THING.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:simpleType name="TypeOfThingIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a TYPE OF THING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="TypeOfValueIdType"/>
+	</xsd:simpleType>
+	<xsd:element name="TypeOfThingRef" type="TypeOfThingRefStructure" abstract="false" substitutionGroup="TypeOfEntityRef">
+		<xsd:annotation>
+			<xsd:documentation>Reference to a TYPE OF THING</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="TypeOfThingRefStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a reference to a TYPE OF THING</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:restriction base="TypeOfValueRefStructure">
+				<xsd:attribute name="ref" type="TypeOfThingIdType" use="required">
+					<xsd:annotation>
+						<xsd:documentation>Identifier of referenced SOMETHING ELSE.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:restriction>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!-- ======================================================================= -->
+	<xsd:simpleType name="ThingTypeEnumeration">
+		<xsd:annotation>
+			<xsd:documentation>Modes of transport applicable to private and non-timetabled transport.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="nextBig"/>
+			<xsd:enumeration value="nextSmall"/>
+			<xsd:enumeration value="soWhat"/>
+			<xsd:enumeration value="smelly"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+</xsd:schema>

--- a/schema/1.03/xsd/ynotation/netex_thing_version-v0.1.xsd
+++ b/schema/1.03/xsd/ynotation/netex_thing_version-v0.1.xsd
@@ -1,1 +1,235 @@
-<?xml version="1.0" encoding="UTF-8"?><xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1" id="netex_Thing">	<xsd:include schemaLocation="netex_thing_support-v0.1.xsd"/>	<xsd:include schemaLocation="../netex_framework/netex_responsibility/netex_typeOfValue_version-v0.1.xsd"/>	<!-- === NOTATION EXAMPLE E==== =================================================== -->	<!-- ======================================================================= -->	<!-- ==== Thing ========================================================= -->	<xsd:element name="Thing" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A THING.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="Thing_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="ThingGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="ThingIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of THING</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="Thing_VersionStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for an THING.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="DataManagedObjectStructure">				<xsd:sequence>					<xsd:group ref="ThingGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="ThingGroup">		<xsd:annotation>			<xsd:documentation>Elements for a THING.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Name" type="MultilingualString" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Name of THING.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="ThingType" type="ThingTypeEnumeration" minOccurs="1">				<xsd:annotation>					<xsd:documentation>Type of THING.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="ParentThingRef" type="ThingRefStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Parent THING.</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="childThings" type="childThings_RelStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Component parts that make up THING</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="somethingElses" type="somethingElseRefs_RelStructure" minOccurs="0">				<xsd:annotation>					<xsd:documentation>SOMETHING ELSEs associated with this THING.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ==== Child Thing ======================================================== -->	<xsd:complexType name="childThings_RelStructure">		<xsd:annotation>			<xsd:documentation>Type for a list of CHILD THINGs</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="strictContainmentAggregationStructure">				<xsd:sequence>					<xsd:element ref="ChildThing" minOccurs="2" maxOccurs="unbounded"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:element name="ChildThing" type="ChildThing_VersionedChildStructure" abstract="false" substitutionGroup="VersionedChild">		<xsd:annotation>			<xsd:documentation>A CHILD THING.</xsd:documentation>		</xsd:annotation>	</xsd:element>	<xsd:complexType name="ChildThing_VersionedChildStructure" abstract="false">		<xsd:annotation>			<xsd:documentation>Type for a CHILD THING.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="VersionedChildStructure">				<xsd:sequence>					<xsd:element ref="ThingRef" minOccurs="0"/>					<xsd:group ref="ChildThingGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="ChildThingGroup">		<xsd:annotation>			<xsd:documentation>Elements for a CHILD THING.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Name" type="MultilingualString" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Name of Thing</xsd:documentation>				</xsd:annotation>			</xsd:element>			<xsd:element name="IsCool" type="xsd:boolean" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Name of Link.</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ==== Type of Thing ================================================= -->	<xsd:element name="TypeOfThing" abstract="false" substitutionGroup="TypeOfValue">		<xsd:annotation>			<xsd:documentation>Classification of a THING.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="TypeOfThing_ValueStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="TypeOfValueGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:sequence>								<xsd:element name="Url" type="xsd:anyURI" minOccurs="0">									<xsd:annotation>										<xsd:documentation>Url of Thing</xsd:documentation>									</xsd:annotation>								</xsd:element>							</xsd:sequence>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" type="TypeOfValueIdType" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of TYPE OF THING</xsd:documentation>						</xsd:annotation>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="TypeOfThing_ValueStructure" abstract="false">		<xsd:annotation>			<xsd:documentation>Type for a TYPE OF THING</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="TypeOfValue_VersionStructure">				<xsd:sequence>					<xsd:group ref="TypeOfThingGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="TypeOfThingGroup">		<xsd:annotation>			<xsd:documentation>Elements for a TYPE OF THING.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Url" type="xsd:anyURI" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Url of Thing</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ===== SomethingElse =============================================== -->	<xsd:element name="SomethingElse" abstract="false" substitutionGroup="DataManagedObject">		<xsd:annotation>			<xsd:documentation>A SOMETHING ELSE.</xsd:documentation>		</xsd:annotation>		<xsd:complexType>			<xsd:complexContent>				<xsd:restriction base="SomethingElse_VersionStructure">					<xsd:sequence>						<xsd:sequence>							<xsd:group ref="DataManagedObjectGroup"/>						</xsd:sequence>						<xsd:sequence>							<xsd:group ref="SomethingElseGroup"/>						</xsd:sequence>					</xsd:sequence>					<xsd:attribute name="id" use="optional">						<xsd:annotation>							<xsd:documentation>Identifier of SOMETHING ELSE</xsd:documentation>						</xsd:annotation>						<xsd:simpleType>							<xsd:restriction base="SomethingElseIdType"/>						</xsd:simpleType>					</xsd:attribute>				</xsd:restriction>			</xsd:complexContent>		</xsd:complexType>	</xsd:element>	<xsd:complexType name="SomethingElse_VersionStructure" abstract="true">		<xsd:annotation>			<xsd:documentation>Type for an SOMETHING ELSE.</xsd:documentation>		</xsd:annotation>		<xsd:complexContent>			<xsd:extension base="DataManagedObjectStructure">				<xsd:sequence>					<xsd:group ref="SomethingElseGroup"/>				</xsd:sequence>			</xsd:extension>		</xsd:complexContent>	</xsd:complexType>	<xsd:group name="SomethingElseGroup">		<xsd:annotation>			<xsd:documentation>Elements for a SOMETHING ELSE.</xsd:documentation>		</xsd:annotation>		<xsd:sequence>			<xsd:element name="Name" type="MultilingualString" minOccurs="0">				<xsd:annotation>					<xsd:documentation>Alternative code for legacy compatibility</xsd:documentation>				</xsd:annotation>			</xsd:element>		</xsd:sequence>	</xsd:group>	<!-- ======================================================================= --></xsd:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:core="http://www.govtalk.gov.uk/core" xmlns="http://www.netex.org.uk/netex" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" targetNamespace="http://www.netex.org.uk/netex" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1" id="netex_Thing">
+	<xsd:include schemaLocation="netex_thing_support-v0.1.xsd"/>
+	<xsd:include schemaLocation="../netex_framework/netex_responsibility/netex_typeOfValue_version-v0.1.xsd"/>
+	<!-- === NOTATION EXAMPLE E==== =================================================== -->
+	<!-- ======================================================================= -->
+	<!-- ==== Thing ========================================================= -->
+	<xsd:element name="Thing" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A THING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="Thing_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="ThingGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="ThingIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of THING</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="Thing_VersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for an THING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:sequence>
+					<xsd:group ref="ThingGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ThingGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a THING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of THING.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ThingType" type="ThingTypeEnumeration" minOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Type of THING.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ParentThingRef" type="ThingRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Parent THING.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="childThings" type="childThings_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Component parts that make up THING</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="somethingElses" type="somethingElseRefs_RelStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>SOMETHING ELSEs associated with this THING.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== Child Thing ======================================================== -->
+	<xsd:complexType name="childThings_RelStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for a list of CHILD THINGs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="strictContainmentAggregationStructure">
+				<xsd:sequence>
+					<xsd:element ref="ChildThing" minOccurs="2" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="ChildThing" type="ChildThing_VersionedChildStructure" abstract="false" substitutionGroup="VersionedChild">
+		<xsd:annotation>
+			<xsd:documentation>A CHILD THING.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ChildThing_VersionedChildStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a CHILD THING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="VersionedChildStructure">
+				<xsd:sequence>
+					<xsd:element ref="ThingRef" minOccurs="0"/>
+					<xsd:group ref="ChildThingGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="ChildThingGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a CHILD THING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of Thing</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="IsCool" type="xsd:boolean" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Name of Link.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ==== Type of Thing ================================================= -->
+	<xsd:element name="TypeOfThing" abstract="false" substitutionGroup="TypeOfValue">
+		<xsd:annotation>
+			<xsd:documentation>Classification of a THING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="TypeOfThing_ValueStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="TypeOfValueGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:sequence>
+								<xsd:element name="Url" type="xsd:anyURI" minOccurs="0">
+									<xsd:annotation>
+										<xsd:documentation>Url of Thing</xsd:documentation>
+									</xsd:annotation>
+								</xsd:element>
+							</xsd:sequence>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" type="TypeOfValueIdType" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of TYPE OF THING</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="TypeOfThing_ValueStructure" abstract="false">
+		<xsd:annotation>
+			<xsd:documentation>Type for a TYPE OF THING</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="TypeOfValue_VersionStructure">
+				<xsd:sequence>
+					<xsd:group ref="TypeOfThingGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="TypeOfThingGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a TYPE OF THING.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Url" type="xsd:anyURI" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Url of Thing</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ===== SomethingElse =============================================== -->
+	<xsd:element name="SomethingElse" abstract="false" substitutionGroup="DataManagedObject">
+		<xsd:annotation>
+			<xsd:documentation>A SOMETHING ELSE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:restriction base="SomethingElse_VersionStructure">
+					<xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="DataManagedObjectGroup"/>
+						</xsd:sequence>
+						<xsd:sequence>
+							<xsd:group ref="SomethingElseGroup"/>
+						</xsd:sequence>
+					</xsd:sequence>
+					<xsd:attribute name="id" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>Identifier of SOMETHING ELSE</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:restriction base="SomethingElseIdType"/>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:restriction>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="SomethingElse_VersionStructure" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Type for an SOMETHING ELSE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:sequence>
+					<xsd:group ref="SomethingElseGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:group name="SomethingElseGroup">
+		<xsd:annotation>
+			<xsd:documentation>Elements for a SOMETHING ELSE.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="Name" type="MultilingualString" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Alternative code for legacy compatibility</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:group>
+	<!-- ======================================================================= -->
+</xsd:schema>


### PR DESCRIPTION
@nick-knowles and @Aurige:

Continuing pull request #7, we have now added the neccessary explicit SIRI schema imports to ensure that the PublicationDelivery schema validates with Xerces (rather than relying only on the built in XMLSpy validator, which may implicitly load dependencies and thus validate despite missing imports) as well as ensuring automated JAX-B generation of Java-classes from NeTEx without the need for extensive explicit bindings.

We have also corrected an invalid schema loctation in the siri_types XSD.

All changes have been tested by ensuring successful validation, both with XMLSpy and Xerces, of top level schemas as well as example XML files published in the NeTEx-XML project.

Best regards
K. Syversen
www.nasjonalreiseplanlegger.com
